### PR TITLE
Keep metadata about some command args in the client

### DIFF
--- a/lib/razor/cli/navigate.yaml
+++ b/lib/razor/cli/navigate.yaml
@@ -1,0 +1,14 @@
+---
+
+# This file helps Razor::CLI::Navigate with a few things by annotating the
+# API. Ultimately, this should be something the server provides. But until
+# we better understand what sort of annotation we need from the server,
+# we'll keep this with the client.
+
+commands:
+  create-tag:
+    args:
+      rule: json
+  update-tag:
+    args:
+      rule: json


### PR DESCRIPTION
Ultimately, we want the server to provide enough information so that
client(s) can deal with the API in fairly generic terms; to that end, the
server will have to provide some metadata around commands, collections etc.

Until we have figured out what that metadata should be and what shape it
should be, we'll store it in a separate YAML file with the client so that
the client will mostly work as if the server provided that metadata without
making the corresponding API commitment.

This is needed to make the fix for
https://github.com/puppetlabs/razor-server/issues/68 (new command
update-tag) usable
