### PR TITLE
Fix for displaying a single item from a collection

### DIFF
--- a/lib/razor/cli/format.rb
+++ b/lib/razor/cli/format.rb
@@ -52,8 +52,6 @@ module Razor::CLI
         value = object[f]
         output = "#{f.rjust key_indent + 2}: "
         output << case value
-        when Hash
-          "\n" + format_object(value, key_indent + 4).rstrip
         when Array
            if value.all? { |v| v.is_a?(String) }
              "[" + value.map(&:inspect).join(",") + "]"


### PR DESCRIPTION
This is to fix the backtrace caused by trying to display a single item out of a collection, to reproduce, create a broker and attempt to display the single entry by name:

```
razor create-broker --name=puppetmaster --broker-type=puppet
bin/razor brokers puppetmaster
/root/testing/razor-client/lib/razor/cli/format.rb:49:in `+': nil can't be coerced into Fixnum (TypeError)
        from /root/testing/razor-client/lib/razor/cli/format.rb:49:in `format_default_object'
        from /root/testing/razor-client/lib/razor/cli/format.rb:43:in `format_object'
        from /root/testing/razor-client/lib/razor/cli/format.rb:56:in `block in format_default_object'
        from /root/testing/razor-client/lib/razor/cli/format.rb:51:in `map'
        from /root/testing/razor-client/lib/razor/cli/format.rb:51:in `format_default_object'
        from /root/testing/razor-client/lib/razor/cli/format.rb:43:in `format_object'
        from /root/testing/razor-client/lib/razor/cli/format.rb:22:in `format_document'
        from ./bin/razor:15:in `<main>'
```

After fix:

```
bin/razor brokers puppetmaster
From http://10.2.149.52:8080/api/collections/brokers/puppetmaster:

             id: "http://10.2.149.52:8080/api/collections/brokers/puppetmaster"
           name: "puppetmaster"
           spec: "/spec/object/broker"
  configuration: {}
    broker-type: "puppet"
```
