### PR TITLE
Do not JSON-decode tag rules twice

### DIFF
--- a/lib/razor/cli/navigate.rb
+++ b/lib/razor/cli/navigate.rb
@@ -67,10 +67,7 @@ module Razor::CLI
           body[$1] = convert_arg(cmd["name"], $1, ($3 || @segments.shift))
         end
       end
-      # Parse JSON-valued arguments
-      if cmd["name"] == "create-tag" && body["rule"]
-        body["rule"] = JSON::parse(body["rule"])
-      end
+
       body = JSON::parse(File::read(body["json"])) if body["json"]
       [cmd, body]
     end


### PR DESCRIPTION
The Navigate::extract_command method calls JSON::parse twice when passed
the create-tag command's "rule" argument value, which triggers an exception
and crashes the client. The second call is unnecessary, so this patch
removes it.
