### PR TITLE
* lib/razor/cli/navigate.rb (move_to): do not convert keys that look lik...

### DIFF
--- a/lib/razor/cli/navigate.rb
+++ b/lib/razor/cli/navigate.rb
@@ -95,7 +95,6 @@ module Razor::CLI
     end
 
     def move_to(key)
-      key = key.to_i if key.to_i.to_s == key
       if @doc.is_a? Array
         obj = @doc.find {|x| x.is_a?(Hash) and x["name"] == key }
       elsif @doc.is_a? Hash


### PR DESCRIPTION
...e ints

The code was converting a key that looked like an integer to an integer,
solely based on whether that conversion could be done or not. That is wrong
for several reasons, most importantly because the data type of what we
compare the key against in the documents received from the server does and
should not depend on whether something can be represented as an integer or
not.

In the code that used the converted key, it was used to either find an
entry in an array of hashes where the 'name' property of the entry matches
the key, or to retrieve an entry from the (Hash) document we are working
on. In both cases, what we compare the key to must be a string; if it is
not a string, that's a violation of the API contract, and the client's
behavior just glossed over that.
