### PR TITLE
Fixing spec test

### DIFF
--- a/spec/cli/navigate_spec.rb
+++ b/spec/cli/navigate_spec.rb
@@ -37,7 +37,7 @@ describe Razor::CLI::Navigate do
   context "with invalid parameter", :vcr do
     it "should fail with bad JSON" do
       nav = Razor::CLI::Parse.new(['update-tag-rule', '--name', 'tag_1', '--rule', 'not-json']).navigate
-      expect{nav.get_document}.to raise_error(ArgumentError, "Invalid JSON for argument 'rule': unexpected token at 'not-json'")
+      expect{nav.get_document}.to raise_error(ArgumentError, /Invalid JSON for argument 'rule'/)
     end
   end
 


### PR DESCRIPTION
Some versions of the JSON parser include a line number in the error message, causing the expected message to fail.

For https://tickets.puppetlabs.com/browse/RAZOR-135
