### PR TITLE
Report HTTP errors to the user

### DIFF
--- a/lib/razor/cli/parse.rb
+++ b/lib/razor/cli/parse.rb
@@ -57,10 +57,16 @@ HELP
         output << <<-UNAUTH
 Error: Credentials are required to connect to the server at #{@api_url}"
 UNAUTH
-      rescue
+       rescue RestClient::InternalServerError => exception
+         output << <<-EOT
+Error: the server reported an internal error satisfying the request:
+#{exception.http_body}
+ EOT
+      rescue => exception
         output << <<-ERR
-Error: Could not connect to the server at #{@api_url}. More help is available after pointing
-the client to a Razor server
+Error: failed to communicate with the server at #{@api_url}.
+More help is available after successfully communicating with the server.
+#{exception.class}: #{exception}
 ERR
       end
       output


### PR DESCRIPTION
This change actually reports HTTP errors to the user, including the HTTP body,
when the server fails.  This, in turn, allows the server to actually
communicate information to the user about why things went wrong.

It also adjusts the wording of the default message to be clearer about the
"failure" -- that communication failed, not necessarily just connectivity
failed with the server.

https://tickets.puppetlabs.com/browse/RAZOR-158

Signed-off-by: Daniel Pittman <daniel@rimspace.net>