### PR TITLE
Show command id in create commands

### DIFF
--- a/lib/razor/cli/format.rb
+++ b/lib/razor/cli/format.rb
@@ -32,7 +32,11 @@ module Razor::CLI
     end
 
     def format_reference_object(ref, indent = 0)
-      output = ' '* indent + "#{ref['name']} => #{ref['id'].to_s.ljust 4}"
+      key_indent = indent + [ref['name'].size, 'command'.size].max
+
+      output = "#{ref['name'].rjust key_indent + 2} => #{ref['id'].to_s.ljust 4}"
+      output += "\n#{'command'.rjust key_indent + 2} => #{ref['command'].to_s.ljust 4}" if ref['command']
+      output
     end
 
 


### PR DESCRIPTION
When a create command, e.g. `create-repo` is called, the user only sees the URL to the new repo, when they should also see the command that they just executed. This adds that information to the CLI.
