### PR TITLE
Allow formatting of non-spec attributes

### DIFF
--- a/lib/razor/cli/document.rb
+++ b/lib/razor/cli/document.rb
@@ -5,10 +5,14 @@ module Razor::CLI
       extend Forwardable
     attr_reader 'spec', 'items', 'format_view'
     def initialize(doc, format_type)
-      @spec = doc['spec']
+      if doc['spec'].is_a?(Array)
+        @spec, @remaining_navigation = doc['spec']
+      else
+        @spec = doc['spec']
+      end
       @command = doc['command']
-      @items = (doc['items'] or Array[doc])
-      @format_view = Razor::CLI::Views.find_formatting(spec, format_type)
+      @items = doc['items'] || Array[doc]
+      @format_view = Razor::CLI::Views.find_formatting(spec, format_type, @remaining_navigation)
 
       @items = hide_or_transform_elements!(items, format_view)
     end

--- a/lib/razor/cli/format.rb
+++ b/lib/razor/cli/format.rb
@@ -68,7 +68,7 @@ module Razor::CLI
     end
 
     def format_default_object(object, indent = 0 )
-      fields = (PriorityKeys & object.keys) + (object.keys - PriorityKeys)
+      fields = display_fields(object)
       key_indent = indent + fields.map {|f| f.length}.max
       output = ""
       fields.map do |f|
@@ -96,6 +96,10 @@ module Razor::CLI
           end
         end
       end.join "\n"
+    end
+
+    def display_fields(object)
+      (PriorityKeys & object.keys) + (object.keys - PriorityKeys) - ['+spec']
     end
   end
 end

--- a/lib/razor/cli/views.rb
+++ b/lib/razor/cli/views.rb
@@ -9,10 +9,12 @@ module Razor::CLI
       Razor::CLI::Transforms.send(transform_name || 'identity', item)
     end
 
-    def find_formatting(spec, format)
+    def find_formatting(spec, format, remaining_navigation)
+      remaining_navigation ||= ''
       # Scope will narrow by traversing the spec.
       scope = views
       spec = spec ? spec.split('/').drop_while { |i| i != 'collections'} : []
+      spec = spec + remaining_navigation.split(' ')
       while spec.any?
         val = spec.shift
         scope = (scope[val] or {})

--- a/lib/razor/cli/views.yaml
+++ b/lib/razor/cli/views.yaml
@@ -50,6 +50,20 @@ collections:
           state:
           tags:
             +format: join_names
+      tags:
+        +short:
+          +layout: table
+          +show:
+            name:
+            rule:
+              +format: nested
+            nodes:
+              +format: count_column
+            policies:
+              +format: count_column
+      hw_info:
+        +short:
+          +layout: list
     log:
       +short:
         +layout: table


### PR DESCRIPTION
In cases like `razor nodes node1 tags`, navigation would previously reach the end of the navigation string and be left with just an array. With this array, it was not possible to customize the output (and was throwing an error).

This fix allows the navigation to retain the parent's spec string and store the navigation that was not consumed. The view can then format the output as desired.

Fixes https://tickets.puppetlabs.com/browse/RAZOR-242
