### PR TITLE
Indicate available additional details

### DIFF
--- a/lib/razor/cli/document.rb
+++ b/lib/razor/cli/document.rb
@@ -3,7 +3,7 @@ require 'forwardable'
 module Razor::CLI
   class Document
       extend Forwardable
-    attr_reader 'spec', 'items', 'format_view'
+    attr_reader 'spec', 'items', 'format_view', 'original_items'
     def initialize(doc, format_type)
       if doc['spec'].is_a?(Array)
         @spec, @remaining_navigation = doc['spec']
@@ -12,8 +12,10 @@ module Razor::CLI
       end
       @command = doc['command']
       @items = doc['items'] || Array[doc]
-      @format_view = Razor::CLI::Views.find_formatting(spec, format_type, @remaining_navigation)
+      @format_view = Razor::CLI::Views.find_formatting(@spec, format_type, @remaining_navigation)
 
+      # Untransformed and unordered for displaying nested views.
+      @original_items = @items
       @items = hide_or_transform_elements!(items, format_view)
     end
 

--- a/lib/razor/cli/parse.rb
+++ b/lib/razor/cli/parse.rb
@@ -101,7 +101,7 @@ ERR
       !!@dump
     end
 
-    attr_reader :api_url, :format
+    attr_reader :api_url, :format, :args
 
     def initialize(args)
       parse_and_set_api_url(ENV["RAZOR_API"] || DEFAULT_RAZOR_API, :env)

--- a/spec/cli/format_spec.rb
+++ b/spec/cli/format_spec.rb
@@ -1,0 +1,54 @@
+# Needed to make the client work on Ruby 1.8.7
+unless Kernel.respond_to?(:require_relative)
+  module Kernel
+    def require_relative(path)
+      require File.join(File.dirname(caller[0]), path.to_str)
+    end
+  end
+end
+
+require "rspec/expectations"
+require_relative '../spec_helper'
+
+describe Razor::CLI::Format do
+  include described_class
+
+  def format(doc, args = {})
+    args = {:format => '+short', :args => ['something', 'else']}.merge(args)
+    parse = double(args)
+    format_document doc, parse
+  end
+
+  context 'additional details' do
+    it "tells additional details for a hash" do
+      doc = {'abc' => {'def' => 'ghi'}}
+      result = format doc
+      result.should =~ /Query additional details via: `razor something else \[abc\]`\z/
+    end
+    it "tells additional details for an array" do
+      doc = {'abc' => ['def']}
+      result = format doc
+      result.should =~ /Query additional details via: `razor something else \[abc\]`\z/
+    end
+    it "tells no additional details for a string" do
+      doc = {'abc' => 'def'}
+      result = format doc
+      result.should_not =~ /Query additional details/
+    end
+    it "hides array spec array from additional details" do
+      doc = {'abc' => [], 'spec' => ['def', 'jkl']}
+      result = format doc
+      result.should =~ /Query additional details via: `razor something else \[abc\]`\z/
+    end
+    it "hides array +spec array from additional details" do
+      doc = {'abc' => [], '+spec' => ['def', 'jkl']}
+      result = format doc
+      result.should =~ /Query additional details via: `razor something else \[abc\]`\z/
+    end
+    it "tells how to query by name" do
+      doc = {'items' => [{'name' => 'entirely'}, {'name' => 'bar'} ]}
+      result = format doc
+      result.should =~ /Query an entry by including its name, e.g. `razor something else entirely`\z/
+    end
+  end
+end


### PR DESCRIPTION
When the user ran `razor nodes node1`, it wasn't clear that the tree could be further traversed via e.g. `razor nodes node1 tags`. This adds a line at the end of the display to tell the next items that can be traversed.

Fixes https://tickets.puppetlabs.com/browse/RAZOR-241
