### PR TITLE
Standardize output when no items present

### DIFF
--- a/lib/razor/cli/format.rb
+++ b/lib/razor/cli/format.rb
@@ -22,13 +22,10 @@ module Razor::CLI
       format = parse.format
       arguments = parse.args
       doc = Razor::CLI::Document.new(doc, format)
+      return "There are no items for this query." if doc.items.empty?
       case (doc.format_view['+layout'] or 'list')
       when 'list'
-        case
-          when doc.items.size > 0 then
-            format_objects(doc.items) + String(additional_details(doc.original_items, arguments))
-          else "[none]"
-        end.chomp
+        format_objects(doc.items) + String(additional_details(doc.original_items, arguments)).chomp
       when 'table'
         case doc.items
           when Array then

--- a/spec/cli/format_spec.rb
+++ b/spec/cli/format_spec.rb
@@ -14,7 +14,7 @@ describe Razor::CLI::Format do
   include described_class
 
   def format(doc, args = {})
-    args = {:format => '+short', :args => ['something', 'else']}.merge(args)
+    args = {:format => 'short', :args => ['something', 'else']}.merge(args)
     parse = double(args)
     format_document doc, parse
   end
@@ -54,6 +54,19 @@ describe Razor::CLI::Format do
       doc = {'items' => [{'name' => 'entirely'}, {'name' => 'bar'} ]}
       result = format doc
       result.should =~ /Query an entry by including its name, e.g. `razor something else entirely`\z/
+    end
+  end
+
+  context 'empty display' do
+    it "works right when it has nothing to display as a table" do
+      doc = {"spec"=>"http://api.puppetlabs.com/razor/v1/collections/policies", "items"=>[]}
+      result = format doc
+      result.should == "There are no items for this query."
+    end
+    it "works right when it has nothing to display as a list" do
+      doc = {"spec"=>"http://api.puppetlabs.com/razor/v1/collections/policies/member", "items"=>[]}
+      result = format doc
+      result.should == "There are no items for this query."
     end
   end
 end


### PR DESCRIPTION
This standardizes the output using the phrase, "There are no items for this query." if there are no items in a list, e.g. `razor policies`.

Fixes https://tickets.puppetlabs.com/browse/RAZOR-243
