### PR TITLE
Hide add'l details from command help text

### DIFF
--- a/lib/razor/cli/document.rb
+++ b/lib/razor/cli/document.rb
@@ -11,12 +11,21 @@ module Razor::CLI
         @spec = doc['spec']
       end
       @command = doc['command']
+      if doc.has_key?('items')
+        @type = :list
+      else
+        @type = :single
+      end
       @items = doc['items'] || Array[doc]
       @format_view = Razor::CLI::Views.find_formatting(@spec, format_type, @remaining_navigation)
 
       # Untransformed and unordered for displaying nested views.
       @original_items = @items
       @items = hide_or_transform_elements!(items, format_view)
+    end
+
+    def is_list?
+      @type == :list
     end
 
     private

--- a/spec/cli/format_spec.rb
+++ b/spec/cli/format_spec.rb
@@ -14,7 +14,7 @@ describe Razor::CLI::Format do
   include described_class
 
   def format(doc, args = {})
-    args = {:format => 'short', :args => ['something', 'else']}.merge(args)
+    args = {:format => 'short', :args => ['something', 'else'], :show_command_help? => false}.merge(args)
     parse = double(args)
     format_document doc, parse
   end


### PR DESCRIPTION
The command help was erroneously including
the text used to tell the user how to dive deeper
into a collection. This hides that text.

Fixes https://tickets.puppetlabs.com/browse/RAZOR-269
