### PR TITLE
Add Puppet Labs internal build infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ pkg/
 /Gemfile.local*
 /coverage
 /.project
+/ext/packaging/

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,5 @@
 require 'rake'
-require "bundler/gem_tasks"
+require 'yaml'
 
 # Needed to make the client work on Ruby 1.8.7
 unless Kernel.respond_to?(:require_relative)
@@ -18,20 +18,59 @@ namespace :bundler do
   end
 end
 
-namespace :spec do
-  require 'rspec/core'
-  require 'rspec/core/rake_task'
+if defined?(RSpec::Core::RakeTask)
+  namespace :spec do
+    require 'rspec/core'
+    require 'rspec/core/rake_task'
 
-  desc <<EOS
+    desc <<EOS
 Run all specs. Set VCR_RECORD to 'all' to rerecord and to 'new_episodes'
 to record new tests. Tapes are in #{VCR_LIBRARY}
 EOS
-  RSpec::Core::RakeTask.new(:all => :"bundler:setup") do |t|
-    t.pattern = 'spec/**/*_spec.rb'
+    RSpec::Core::RakeTask.new(:all => :"bundler:setup") do |t|
+      t.pattern = 'spec/**/*_spec.rb'
+    end
   end
 end
 
 desc "Erase all VCR recordings"
 task :"vcr:erase" do
   erase_vcr_library
+end
+
+##############################################################################
+# Support for our internal packaging toolchain.  Most people outside of Puppet
+# Labs will never actually need to deal with these.
+begin
+  load File.join(File.dirname(__FILE__), 'ext', 'packaging', 'packaging.rake')
+rescue LoadError
+end
+
+begin
+  @build_defaults ||= YAML.load_file('ext/build_defaults.yaml')
+  @packaging_url  = @build_defaults['packaging_url']
+  @packaging_repo = @build_defaults['packaging_repo']
+rescue => e
+  STDERR.puts "Unable to read the packaging repo info from ext/build_defaults.yaml"
+  STDERR.puts e
+end
+
+namespace :package do
+  desc "Bootstrap packaging automation, e.g. clone into packaging repo"
+  task :bootstrap do
+    if File.exist?("ext/#{@packaging_repo}")
+      puts "It looks like you already have ext/#{@packaging_repo}. If you don't like it, blow it away with package:implode."
+    else
+      cd 'ext' do
+        %x{git clone #{@packaging_url}}
+      end
+    end
+  end
+
+  desc "Remove all cloned packaging automation"
+  task :implode do
+    if @packaging_repo and not @packaging_repo.empty?
+      rm_rf "ext/#{@packaging_repo}"
+    end
+  end
 end

--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -1,0 +1,22 @@
+---
+packaging_url: 'git://github.com/puppetlabs/packaging.git --branch=master'
+packaging_repo: 'packaging'
+default_cow: ''
+cows: ''
+pbuild_conf: '/etc/pbuilderrc'
+packager: 'puppet'
+gpg_name: 'info@puppetlabs.com'
+gpg_key: '4BD6EC30'
+sign_tar: FALSE
+# a space separated list of mock configs
+final_mocks: ''
+yum_host: 'yum.puppetlabs.com'
+yum_repo_path: '/opt/repository/yum/'
+build_gem: TRUE
+build_dmg: FALSE
+build_ips: FALSE
+build_pe:  FALSE
+apt_host: 'apt.puppetlabs.com'
+apt_repo_url: 'http://apt.puppetlabs.com'
+apt_repo_path: '/opt/repository/incoming'
+tar_host: 'downloads.puppetlabs.com'

--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -1,0 +1,35 @@
+---
+project: 'razor-client'
+author: 'Puppet Labs'
+email: 'info@puppetlabs.com'
+homepage: 'http://puppetlabs.com/puppet/puppet-enterprise'
+summary: 'Razor is an advanced provisioning application'
+description: |
+  Razor is an advanced provisioning application which can deploy both bare-metal
+  and virtual systems. It's aimed at solving the problem of how to bring new
+  metal into a state where your existing DevOps/configuration management
+  workflows can take it over.
+
+  This provides the client application gem, used to provide CLI access and control
+  to users of razor-server.
+# automatically burn our version into the generated source
+version_file: 'lib/razor/cli/version.rb'
+update_version_file: true
+# files and gem_files are space separated lists (or arrays)
+files:
+  - 'Gemfile*'
+  - razor-client.gemspec
+  - bin
+  - lib
+  - '*.md'
+  - LICENSE
+gem_files: '{bin,lib}/**/* *.md LICENSE'
+gem_require_path: 'lib'
+gem_test_files: 'spec/**/*'
+gem_executables: 'razor'
+gem_default_executables: 'razor'
+gem_runtime_dependencies:
+  mime-types: '< 2.0'
+  multi_json:
+  rest-client:
+  terminal-table:


### PR DESCRIPTION
This adds support for the internal Puppet Labs build infrastructure to the
client repo, allowing us to integrate shipping the gem with our normal
build tooling.

Signed-off-by: Daniel Pittman daniel@rimspace.net
