### PR TITLE
Additional details special case

### DIFF
--- a/lib/razor/cli/format.rb
+++ b/lib/razor/cli/format.rb
@@ -118,7 +118,7 @@ module Razor::CLI
             when Hash, Array
               f
           end
-        end.sort.compact
+        end.compact.sort
         if list.any?
           "\n\nQuery additional details via: `razor #{arguments.join(' ')} [#{list.join(', ')}]`"
         end

--- a/spec/cli/format_spec.rb
+++ b/spec/cli/format_spec.rb
@@ -50,6 +50,11 @@ describe Razor::CLI::Format do
       result = format doc
       result.should =~ /Query additional details via: `razor something else \[abc\]`\z/
     end
+    it "only shows additional details for nested objects" do
+      doc = {'one-prop' => 'val', 'abc' => [], 'prop' => 'jkl'}
+      result = format doc
+      result.should =~ /Query additional details via: `razor something else \[abc\]`\z/
+    end
     it "tells how to query by name" do
       doc = {'items' => [{'name' => 'entirely'}, {'name' => 'bar'} ]}
       result = format doc


### PR DESCRIPTION
Showing additional details was failing when the results had a mixture of nested and non-nested attributes. This fixes that.

Fixes https://tickets.puppetlabs.com/browse/RAZOR-270
