### PR TITLE
Hide additional details from "create" commands

### DIFF
--- a/lib/razor/cli/format.rb
+++ b/lib/razor/cli/format.rb
@@ -28,11 +28,11 @@ module Razor::CLI
 
       case (doc.format_view['+layout'] or 'list')
       when 'list'
-        format_objects(doc.items) + String(additional_details(doc, arguments)).chomp
+        format_objects(doc.items) + String(additional_details(doc, parse, arguments)).chomp
       when 'table'
         case doc.items
           when Array then
-            get_table(doc.items, doc.format_view) + String(additional_details(doc, arguments))
+            get_table(doc.items, doc.format_view) + String(additional_details(doc, parse, arguments))
           else doc.to_s
         end
       else
@@ -115,10 +115,12 @@ module Razor::CLI
       (PriorityKeys & keys) + (keys - PriorityKeys) - ['+spec']
     end
 
-    def additional_details(doc, arguments)
+    def additional_details(doc, parse, arguments)
       objects = doc.original_items
-      # If every element has the 'name' key, it has nested elements.
-      if doc.is_list? and objects.all? { |it| it.is_a?(Hash) && it.has_key?('name')}
+      if objects.empty? or not parse.query?
+        ""
+      elsif doc.is_list? and objects.all? { |it| it.is_a?(Hash) && it.has_key?('name')}
+        # If every element has the 'name' key, it has nested elements.
         "\n\nQuery an entry by including its name, e.g. `razor #{arguments.join(' ')} #{objects.first['name']}`"
       elsif objects.any?
         object = objects.first

--- a/lib/razor/cli/navigate.rb
+++ b/lib/razor/cli/navigate.rb
@@ -35,11 +35,11 @@ module Razor::CLI
     end
 
     def query?
-      collections.any? { |coll| coll["name"] == @segments.first }
+      @query ||= collections.any? { |coll| coll["name"] == @segments.first }
     end
 
     def command(name)
-      commands.find { |coll| coll["name"] == name }
+      @command ||= commands.find { |coll| coll["name"] == name }
     end
 
     def command?

--- a/lib/razor/cli/parse.rb
+++ b/lib/razor/cli/parse.rb
@@ -1,10 +1,14 @@
 require 'uri'
 require 'optparse'
+require 'forwardable'
 
 module Razor::CLI
 
   class Parse
+    extend Forwardable
     DEFAULT_RAZOR_API = "http://localhost:8080/api"
+
+    def_delegator 'navigate', 'query?'
 
     def get_optparse
       @optparse ||= OptionParser.new do |opts|

--- a/spec/cli/format_spec.rb
+++ b/spec/cli/format_spec.rb
@@ -14,7 +14,7 @@ describe Razor::CLI::Format do
   include described_class
 
   def format(doc, args = {})
-    args = {:format => 'short', :args => ['something', 'else'], :show_command_help? => false}.merge(args)
+    args = {:format => 'short', :args => ['something', 'else'], :query? => true, :show_command_help? => false}.merge(args)
     parse = double(args)
     format_document doc, parse
   end
@@ -59,6 +59,11 @@ describe Razor::CLI::Format do
       doc = {'items' => [{'name' => 'entirely'}, {'name' => 'bar'} ]}
       result = format doc
       result.should =~ /Query an entry by including its name, e.g. `razor something else entirely`\z/
+    end
+    it "hides for commands" do
+      doc = {'items' => [{'name' => 'entirely'}, {'name' => 'bar'} ]}
+      result = format doc, query?: false
+      result.should_not =~ /Query an entry by including its name/
     end
   end
 


### PR DESCRIPTION
When an object was created, the client would display the
'additional details' dialog if the created entity contained
any nested elements, e.g. `configuration` in
`create-broker`. This change causes this to only be
displayed when the user's command is a query.

Fixes https://tickets.puppetlabs.com/browse/RAZOR-273
