### PR TITLE
CLI JSON object should accept numbers in key

### DIFF
--- a/lib/razor/cli/navigate.rb
+++ b/lib/razor/cli/navigate.rb
@@ -102,7 +102,7 @@ module Razor::CLI
           # `--arg=value` or `--arg value`
           arg, value = [$1, $3]
           value = @segments.shift if value.nil? && @segments[0] !~ /^--/
-          if value =~ /\A([a-zA-Z._-]+)=(\S+)?\z/
+          if value =~ /\A(.+?)=(\S+)?\z/
             # `--arg name=value`
             unless body[arg].nil? or body[arg].is_a?(Hash)
               # Error: `--arg value --arg name=value`

--- a/spec/cli/navigate_spec.rb
+++ b/spec/cli/navigate_spec.rb
@@ -1,3 +1,4 @@
+# -*- encoding: utf-8 -*-
 # Needed to make the client work on Ruby 1.8.7
 unless Kernel.respond_to?(:require_relative)
   module Kernel
@@ -92,7 +93,15 @@ describe Razor::CLI::Navigate do
         nav = Razor::CLI::Parse.new(['create-broker', '--name', 'broker1', '--broker-type', 'puppet',
                                      '--configuration', 'server=puppet.example.org', '--configuration',
                                      'environment=production']).navigate
-        nav.get_document
+        keys = nav.get_document['configuration'].keys
+        keys.should include 'server'
+        keys.should include 'environment'
+      end
+      it "should construct a json object with unicode", :preserve_exact_body_bytes do
+        doc = Razor::CLI::Parse.new(['register-node', '--installed', 'true', '--hw-info', '{"net0": "abcdef"}']).navigate.get_document
+        name = doc['name']
+        nav = Razor::CLI::Parse.new(['modify-node-metadata', '--node', name, '--update', 'keyᓱ123=valueᓱ1']).navigate
+        nav.get_document['metadata'].should == {'keyᓱ123' => 'valueᓱ1'}
       end
       it "should fail with mixed types (array then hash)" do
         nav = Razor::CLI::Parse.new(['create-broker', '--name', 'broker2', '--broker-type', 'puppet',

--- a/spec/fixtures/vcr/Razor_CLI_Navigate/with_multiple_arguments_with_same_name/combining_as_an_object/should_construct_a_json_object_with_unicode.yml
+++ b/spec/fixtures/vcr/Razor_CLI_Navigate/with_multiple_arguments_with_same_name/combining_as_an_object/should_construct_a_json_object_with_unicode.yml
@@ -1,0 +1,412 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:8080/api
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json;charset=utf-8
+      Content-Length:
+      - '4980'
+      Date:
+      - Tue, 03 Jun 2014 23:18:44 GMT
+    body:
+      encoding: UTF-8
+      string: '{"commands":[{"name":"add-policy-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/add-policy-tag","id":"http://localhost:8080/api/commands/add-policy-tag"},{"name":"create-broker","rel":"http://api.puppetlabs.com/razor/v1/commands/create-broker","id":"http://localhost:8080/api/commands/create-broker"},{"name":"create-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/create-policy","id":"http://localhost:8080/api/commands/create-policy"},{"name":"create-repo","rel":"http://api.puppetlabs.com/razor/v1/commands/create-repo","id":"http://localhost:8080/api/commands/create-repo"},{"name":"create-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/create-tag","id":"http://localhost:8080/api/commands/create-tag"},{"name":"create-task","rel":"http://api.puppetlabs.com/razor/v1/commands/create-task","id":"http://localhost:8080/api/commands/create-task"},{"name":"delete-broker","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-broker","id":"http://localhost:8080/api/commands/delete-broker"},{"name":"delete-node","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-node","id":"http://localhost:8080/api/commands/delete-node"},{"name":"delete-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-policy","id":"http://localhost:8080/api/commands/delete-policy"},{"name":"delete-repo","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-repo","id":"http://localhost:8080/api/commands/delete-repo"},{"name":"delete-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-tag","id":"http://localhost:8080/api/commands/delete-tag"},{"name":"disable-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/disable-policy","id":"http://localhost:8080/api/commands/disable-policy"},{"name":"enable-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/enable-policy","id":"http://localhost:8080/api/commands/enable-policy"},{"name":"modify-node-metadata","rel":"http://api.puppetlabs.com/razor/v1/commands/modify-node-metadata","id":"http://localhost:8080/api/commands/modify-node-metadata"},{"name":"modify-policy-max-count","rel":"http://api.puppetlabs.com/razor/v1/commands/modify-policy-max-count","id":"http://localhost:8080/api/commands/modify-policy-max-count"},{"name":"move-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/move-policy","id":"http://localhost:8080/api/commands/move-policy"},{"name":"reboot-node","rel":"http://api.puppetlabs.com/razor/v1/commands/reboot-node","id":"http://localhost:8080/api/commands/reboot-node"},{"name":"register-node","rel":"http://api.puppetlabs.com/razor/v1/commands/register-node","id":"http://localhost:8080/api/commands/register-node"},{"name":"reinstall-node","rel":"http://api.puppetlabs.com/razor/v1/commands/reinstall-node","id":"http://localhost:8080/api/commands/reinstall-node"},{"name":"remove-node-metadata","rel":"http://api.puppetlabs.com/razor/v1/commands/remove-node-metadata","id":"http://localhost:8080/api/commands/remove-node-metadata"},{"name":"remove-policy-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/remove-policy-tag","id":"http://localhost:8080/api/commands/remove-policy-tag"},{"name":"set-node-desired-power-state","rel":"http://api.puppetlabs.com/razor/v1/commands/set-node-desired-power-state","id":"http://localhost:8080/api/commands/set-node-desired-power-state"},{"name":"set-node-hw-info","rel":"http://api.puppetlabs.com/razor/v1/commands/set-node-hw-info","id":"http://localhost:8080/api/commands/set-node-hw-info"},{"name":"set-node-ipmi-credentials","rel":"http://api.puppetlabs.com/razor/v1/commands/set-node-ipmi-credentials","id":"http://localhost:8080/api/commands/set-node-ipmi-credentials"},{"name":"update-node-metadata","rel":"http://api.puppetlabs.com/razor/v1/commands/update-node-metadata","id":"http://localhost:8080/api/commands/update-node-metadata"},{"name":"update-tag-rule","rel":"http://api.puppetlabs.com/razor/v1/commands/update-tag-rule","id":"http://localhost:8080/api/commands/update-tag-rule"}],"collections":[{"name":"brokers","rel":"http://api.puppetlabs.com/razor/v1/collections/brokers","id":"http://localhost:8080/api/collections/brokers"},{"name":"repos","rel":"http://api.puppetlabs.com/razor/v1/collections/repos","id":"http://localhost:8080/api/collections/repos"},{"name":"tags","rel":"http://api.puppetlabs.com/razor/v1/collections/tags","id":"http://localhost:8080/api/collections/tags"},{"name":"policies","rel":"http://api.puppetlabs.com/razor/v1/collections/policies","id":"http://localhost:8080/api/collections/policies"},{"name":"nodes","rel":"http://api.puppetlabs.com/razor/v1/collections/nodes","id":"http://localhost:8080/api/collections/nodes"},{"name":"tasks","rel":"http://api.puppetlabs.com/razor/v1/collections/tasks","id":"http://localhost:8080/api/collections/tasks"},{"name":"commands","rel":"http://api.puppetlabs.com/razor/v1/collections/commands","id":"http://localhost:8080/api/collections/commands"}],"version":{"server":"v0.15.0-3-gb0cbb3f-dirty"}}'
+    http_version:
+  recorded_at: Tue, 03 Jun 2014 23:18:44 GMT
+- request:
+    method: get
+    uri: http://localhost:8080/api/commands/register-node
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Etag:
+      - '"server-version-v0.15.0-3-gb0cbb3f-dirty"'
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json;charset=utf-8
+      Content-Length:
+      - '2936'
+      Date:
+      - Tue, 03 Jun 2014 23:18:44 GMT
+    body:
+      encoding: UTF-8
+      string: '{"name":"register-node","help":{"full":"# SYNOPSIS\nRegister a node
+        with Razor before it is discovered\n\n# DESCRIPTION\nIn order to make brownfield
+        deployments of Razor easier we allow users to\nregister nodes explicitly.  This
+        command allows you to perform the same\nregistration that would happen when
+        a new node checked in, ahead of time.\n\nIn order for this to be effective
+        the hw_info must contain enough information\nthat the node can successfully
+        be matched during the iPXE boot phase.\n\nIf the node matches an existing
+        node, in keeping with the overall policy of\ncommands declaring desired state,
+        the node installed field will be updated to\nmatch the value in this command.\n\nThe
+        final state is that a node with the supplied hardware information, and the\ndesired
+        installed state, will be present in the database, regardless of it\nexisting
+        before hand or not.\n\n# Access Control\n\nThis command''s access control
+        pattern: `commands:register-node`\n\nFor more detail on how the permission
+        strings are structured and work, you can\nsee the [Shiro Permissions documentation][shiro].  That
+        pattern is expanded\nand then a permission check applied to it, before the
+        command is authorized.\n\nThese checks only apply if security is enabled in
+        the Razor configuration\nfile; on this server security is currently disabled.\n\n[shiro]:
+        http://shiro.apache.org/permissions.html\n\n# Attributes\n\n * installed\n   -
+        Should the node be considered ''installed'' already?  Installed nodes are\n     not
+        eligible for policy matching, and will simply boot locally.\n   - This attribute
+        is required.\n   - It must be of type boolean.\n\n * hw-info\n   - The hardware
+        information for the node.  This is used to match the node on first\n     boot
+        with the record in the database.  The order of MAC address assignment in\n     this
+        data is not significant, as a node with reordered MAC addresses will be\n     treated
+        as the same node.\n   - This attribute is required.\n   - It must be of type
+        object.\n   - It must be between 1 and Infinity in length.\n   \n   # Attributes\n   \n    *
+        serial\n      - The DMI serial number of the node\n      - It must be of type
+        string.\n   \n    * asset\n      - The DMI asset tag of the node\n      -
+        It must be of type string.\n   \n    * uuid\n      - The DMI UUID of the node\n      -
+        It must be of type string.\n\n# EXAMPLES\n\n  Register a machine before you
+        boot it, and note that it already has an OS\n  installed, so should not be
+        subject to policy-based reinstallation:\n  \n      {\n        \"hw_info\":
+        {\n          \"net0\":   \"78:31:c1:be:c8:00\",\n          \"net1\":   \"72:00:01:f2:13:f0\",\n          \"net2\":   \"72:00:01:f2:13:f1\",\n          \"serial\":
+        \"xxxxxxxxxxx\",\n          \"asset\":  \"Asset-1234567890\",\n          \"uuid\":   \"Not
+        Settable\"\n        },\n        \"installed\": true\n      }\n"},"schema":{"installed":{"type":"boolean"},"hw-info":{"type":"object"}}}'
+    http_version:
+  recorded_at: Tue, 03 Jun 2014 23:18:45 GMT
+- request:
+    method: get
+    uri: http://localhost:8080/api/commands/register-node
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Etag:
+      - '"server-version-v0.15.0-3-gb0cbb3f-dirty"'
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json;charset=utf-8
+      Content-Length:
+      - '2936'
+      Date:
+      - Tue, 03 Jun 2014 23:18:44 GMT
+    body:
+      encoding: UTF-8
+      string: '{"name":"register-node","help":{"full":"# SYNOPSIS\nRegister a node
+        with Razor before it is discovered\n\n# DESCRIPTION\nIn order to make brownfield
+        deployments of Razor easier we allow users to\nregister nodes explicitly.  This
+        command allows you to perform the same\nregistration that would happen when
+        a new node checked in, ahead of time.\n\nIn order for this to be effective
+        the hw_info must contain enough information\nthat the node can successfully
+        be matched during the iPXE boot phase.\n\nIf the node matches an existing
+        node, in keeping with the overall policy of\ncommands declaring desired state,
+        the node installed field will be updated to\nmatch the value in this command.\n\nThe
+        final state is that a node with the supplied hardware information, and the\ndesired
+        installed state, will be present in the database, regardless of it\nexisting
+        before hand or not.\n\n# Access Control\n\nThis command''s access control
+        pattern: `commands:register-node`\n\nFor more detail on how the permission
+        strings are structured and work, you can\nsee the [Shiro Permissions documentation][shiro].  That
+        pattern is expanded\nand then a permission check applied to it, before the
+        command is authorized.\n\nThese checks only apply if security is enabled in
+        the Razor configuration\nfile; on this server security is currently disabled.\n\n[shiro]:
+        http://shiro.apache.org/permissions.html\n\n# Attributes\n\n * installed\n   -
+        Should the node be considered ''installed'' already?  Installed nodes are\n     not
+        eligible for policy matching, and will simply boot locally.\n   - This attribute
+        is required.\n   - It must be of type boolean.\n\n * hw-info\n   - The hardware
+        information for the node.  This is used to match the node on first\n     boot
+        with the record in the database.  The order of MAC address assignment in\n     this
+        data is not significant, as a node with reordered MAC addresses will be\n     treated
+        as the same node.\n   - This attribute is required.\n   - It must be of type
+        object.\n   - It must be between 1 and Infinity in length.\n   \n   # Attributes\n   \n    *
+        serial\n      - The DMI serial number of the node\n      - It must be of type
+        string.\n   \n    * asset\n      - The DMI asset tag of the node\n      -
+        It must be of type string.\n   \n    * uuid\n      - The DMI UUID of the node\n      -
+        It must be of type string.\n\n# EXAMPLES\n\n  Register a machine before you
+        boot it, and note that it already has an OS\n  installed, so should not be
+        subject to policy-based reinstallation:\n  \n      {\n        \"hw_info\":
+        {\n          \"net0\":   \"78:31:c1:be:c8:00\",\n          \"net1\":   \"72:00:01:f2:13:f0\",\n          \"net2\":   \"72:00:01:f2:13:f1\",\n          \"serial\":
+        \"xxxxxxxxxxx\",\n          \"asset\":  \"Asset-1234567890\",\n          \"uuid\":   \"Not
+        Settable\"\n        },\n        \"installed\": true\n      }\n"},"schema":{"installed":{"type":"boolean"},"hw-info":{"type":"object"}}}'
+    http_version:
+  recorded_at: Tue, 03 Jun 2014 23:18:45 GMT
+- request:
+    method: post
+    uri: http://localhost:8080/api/commands/register-node
+    body:
+      encoding: UTF-8
+      string: '{"installed":true,"hw-info":{"net0":"abcdef"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '46'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json;charset=utf-8
+      Content-Length:
+      - '203'
+      Date:
+      - Tue, 03 Jun 2014 23:18:44 GMT
+    body:
+      encoding: UTF-8
+      string: '{"spec":"http://api.puppetlabs.com/razor/v1/collections/nodes/member","id":"http://localhost:8080/api/collections/nodes/node1","name":"node1","command":"http://localhost:8080/api/collections/commands/1"}'
+    http_version:
+  recorded_at: Tue, 03 Jun 2014 23:18:45 GMT
+- request:
+    method: get
+    uri: http://localhost:8080/api/collections/nodes/node1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json;charset=utf-8
+      Content-Length:
+      - '335'
+      Date:
+      - Tue, 03 Jun 2014 23:18:44 GMT
+    body:
+      encoding: UTF-8
+      string: '{"spec":"http://api.puppetlabs.com/razor/v1/collections/nodes/member","id":"http://localhost:8080/api/collections/nodes/node1","name":"node1","hw_info":{"mac":["abcdef"]},"log":{"id":"http://localhost:8080/api/collections/nodes/node1/log","name":"log"},"tags":[],"state":{"installed":"true","installed_at":"2014-06-03T18:18:45-05:00"}}'
+    http_version:
+  recorded_at: Tue, 03 Jun 2014 23:18:45 GMT
+- request:
+    method: get
+    uri: http://localhost:8080/api
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json;charset=utf-8
+      Content-Length:
+      - '4980'
+      Date:
+      - Tue, 03 Jun 2014 23:18:44 GMT
+    body:
+      encoding: UTF-8
+      string: '{"commands":[{"name":"add-policy-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/add-policy-tag","id":"http://localhost:8080/api/commands/add-policy-tag"},{"name":"create-broker","rel":"http://api.puppetlabs.com/razor/v1/commands/create-broker","id":"http://localhost:8080/api/commands/create-broker"},{"name":"create-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/create-policy","id":"http://localhost:8080/api/commands/create-policy"},{"name":"create-repo","rel":"http://api.puppetlabs.com/razor/v1/commands/create-repo","id":"http://localhost:8080/api/commands/create-repo"},{"name":"create-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/create-tag","id":"http://localhost:8080/api/commands/create-tag"},{"name":"create-task","rel":"http://api.puppetlabs.com/razor/v1/commands/create-task","id":"http://localhost:8080/api/commands/create-task"},{"name":"delete-broker","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-broker","id":"http://localhost:8080/api/commands/delete-broker"},{"name":"delete-node","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-node","id":"http://localhost:8080/api/commands/delete-node"},{"name":"delete-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-policy","id":"http://localhost:8080/api/commands/delete-policy"},{"name":"delete-repo","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-repo","id":"http://localhost:8080/api/commands/delete-repo"},{"name":"delete-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-tag","id":"http://localhost:8080/api/commands/delete-tag"},{"name":"disable-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/disable-policy","id":"http://localhost:8080/api/commands/disable-policy"},{"name":"enable-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/enable-policy","id":"http://localhost:8080/api/commands/enable-policy"},{"name":"modify-node-metadata","rel":"http://api.puppetlabs.com/razor/v1/commands/modify-node-metadata","id":"http://localhost:8080/api/commands/modify-node-metadata"},{"name":"modify-policy-max-count","rel":"http://api.puppetlabs.com/razor/v1/commands/modify-policy-max-count","id":"http://localhost:8080/api/commands/modify-policy-max-count"},{"name":"move-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/move-policy","id":"http://localhost:8080/api/commands/move-policy"},{"name":"reboot-node","rel":"http://api.puppetlabs.com/razor/v1/commands/reboot-node","id":"http://localhost:8080/api/commands/reboot-node"},{"name":"register-node","rel":"http://api.puppetlabs.com/razor/v1/commands/register-node","id":"http://localhost:8080/api/commands/register-node"},{"name":"reinstall-node","rel":"http://api.puppetlabs.com/razor/v1/commands/reinstall-node","id":"http://localhost:8080/api/commands/reinstall-node"},{"name":"remove-node-metadata","rel":"http://api.puppetlabs.com/razor/v1/commands/remove-node-metadata","id":"http://localhost:8080/api/commands/remove-node-metadata"},{"name":"remove-policy-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/remove-policy-tag","id":"http://localhost:8080/api/commands/remove-policy-tag"},{"name":"set-node-desired-power-state","rel":"http://api.puppetlabs.com/razor/v1/commands/set-node-desired-power-state","id":"http://localhost:8080/api/commands/set-node-desired-power-state"},{"name":"set-node-hw-info","rel":"http://api.puppetlabs.com/razor/v1/commands/set-node-hw-info","id":"http://localhost:8080/api/commands/set-node-hw-info"},{"name":"set-node-ipmi-credentials","rel":"http://api.puppetlabs.com/razor/v1/commands/set-node-ipmi-credentials","id":"http://localhost:8080/api/commands/set-node-ipmi-credentials"},{"name":"update-node-metadata","rel":"http://api.puppetlabs.com/razor/v1/commands/update-node-metadata","id":"http://localhost:8080/api/commands/update-node-metadata"},{"name":"update-tag-rule","rel":"http://api.puppetlabs.com/razor/v1/commands/update-tag-rule","id":"http://localhost:8080/api/commands/update-tag-rule"}],"collections":[{"name":"brokers","rel":"http://api.puppetlabs.com/razor/v1/collections/brokers","id":"http://localhost:8080/api/collections/brokers"},{"name":"repos","rel":"http://api.puppetlabs.com/razor/v1/collections/repos","id":"http://localhost:8080/api/collections/repos"},{"name":"tags","rel":"http://api.puppetlabs.com/razor/v1/collections/tags","id":"http://localhost:8080/api/collections/tags"},{"name":"policies","rel":"http://api.puppetlabs.com/razor/v1/collections/policies","id":"http://localhost:8080/api/collections/policies"},{"name":"nodes","rel":"http://api.puppetlabs.com/razor/v1/collections/nodes","id":"http://localhost:8080/api/collections/nodes"},{"name":"tasks","rel":"http://api.puppetlabs.com/razor/v1/collections/tasks","id":"http://localhost:8080/api/collections/tasks"},{"name":"commands","rel":"http://api.puppetlabs.com/razor/v1/collections/commands","id":"http://localhost:8080/api/collections/commands"}],"version":{"server":"v0.15.0-3-gb0cbb3f-dirty"}}'
+    http_version:
+  recorded_at: Tue, 03 Jun 2014 23:18:45 GMT
+- request:
+    method: get
+    uri: http://localhost:8080/api/commands/modify-node-metadata
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Etag:
+      - '"server-version-v0.15.0-3-gb0cbb3f-dirty"'
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json;charset=utf-8
+      Content-Length:
+      - '2610'
+      Date:
+      - Tue, 03 Jun 2014 23:18:44 GMT
+    body:
+      encoding: UTF-8
+      string: '{"name":"modify-node-metadata","help":{"full":"# SYNOPSIS\nPerform
+        various editing operations on node metadata\n\n# DESCRIPTION\nNode metadata
+        can be added, changed, or removed with this command; it contains\na limited
+        editing language to make changes to the existing metadata in an\natomic fashion.\n\nIt
+        can also clear all metadata from a node, although that operation is\nexclusive
+        to all other editing operations, and cannot be performed atomically\nwith
+        them.\n\n# Access Control\n\nThis command''s access control pattern: `commands:modify-node-metadata:%{node}`\n\nWords
+        surrounded by `%{...}` are substitutions from the input data: typically\nthe
+        name of the object being modified, or some other critical detail, these\nallow
+        roles to be granted partial access to modify the system.\n\nFor more detail
+        on how the permission strings are structured and work, you can\nsee the [Shiro
+        Permissions documentation][shiro].  That pattern is expanded\nand then a permission
+        check applied to it, before the command is authorized.\n\nThese checks only
+        apply if security is enabled in the Razor configuration\nfile; on this server
+        security is currently disabled.\n\n[shiro]: http://shiro.apache.org/permissions.html\n\n#
+        Attributes\n\n * node\n   - The name of the node for which to modify metadata.\n   -
+        This attribute is required.\n   - It must be of type string.\n   - It must
+        match the name of an existing node.\n\n * update\n   - The metadata to update\n   -
+        It must be of type object.\n\n * remove\n   - The metadata to remove\n   -
+        It must be of type array.\n\n * clear\n   - Remove all metadata from the node.  Cannot
+        be used together with\n     either ''update'' or ''remove''.\n   - It must
+        be of type boolean.\n   - If present, update, remove must not be present.\n\n
+        * no-replace\n   - If true, the `update` operation will cause this command
+        to fail if the\n     metadata key is already present on the node.  No effect
+        on `remove` or\n     clear.\n   - It must be of type boolean.\n\n# EXAMPLES\n\n  Editing
+        node metadata, by adding and removing some keys, but refusing to\n  modify
+        an existing value already present on a node:\n  \n      {\n          \"node\":
+        \"node1\",\n          \"update\": {\n              \"key1\": \"value1\",\n              \"key2\":
+        \"value2\"\n          }\n          \"remove\": [\"key3\", \"key4\"],\n          \"no-replace\":
+        true\n      }\n  \n  Removing all node metadata:\n  \n      {\"node\": \"node1\",
+        \"clear\": true}\n"},"schema":{"node":{"type":"string"},"update":{"type":"object"},"remove":{"type":"array"},"clear":{"type":"boolean"},"no-replace":{"type":"boolean"}}}'
+    http_version:
+  recorded_at: Tue, 03 Jun 2014 23:18:45 GMT
+- request:
+    method: post
+    uri: http://localhost:8080/api/commands/modify-node-metadata
+    body:
+      encoding: UTF-8
+      string: '{"node":"node1","update":{"keyᓱ123":"valueᓱ1"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '51'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json;charset=utf-8
+      Content-Length:
+      - '203'
+      Date:
+      - Tue, 03 Jun 2014 23:18:44 GMT
+    body:
+      encoding: UTF-8
+      string: '{"spec":"http://api.puppetlabs.com/razor/v1/collections/nodes/member","id":"http://localhost:8080/api/collections/nodes/node1","name":"node1","command":"http://localhost:8080/api/collections/commands/2"}'
+    http_version:
+  recorded_at: Tue, 03 Jun 2014 23:18:45 GMT
+- request:
+    method: get
+    uri: http://localhost:8080/api/collections/nodes/node1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json;charset=utf-8
+      Content-Length:
+      - '368'
+      Date:
+      - Tue, 03 Jun 2014 23:18:44 GMT
+    body:
+      encoding: UTF-8
+      string: '{"spec":"http://api.puppetlabs.com/razor/v1/collections/nodes/member","id":"http://localhost:8080/api/collections/nodes/node1","name":"node1","hw_info":{"mac":["abcdef"]},"log":{"id":"http://localhost:8080/api/collections/nodes/node1/log","name":"log"},"tags":[],"metadata":{"keyᓱ123":"valueᓱ1"},"state":{"installed":"true","installed_at":"2014-06-03T18:18:45-05:00"}}'
+    http_version:
+  recorded_at: Tue, 03 Jun 2014 23:18:45 GMT
+recorded_with: VCR 2.5.0


### PR DESCRIPTION
The client can now construct the JSON object sent to the server via CLI using the `--argument key=value` syntax. This commit lifts the unnecessary restriction that the key cannot contain numbers.

Fixes https://tickets.puppetlabs.com/browse/RAZOR-275
