### PR TITLE
Show user-friendly error for client/server incompatibility

### DIFF
--- a/lib/razor/cli/navigate.rb
+++ b/lib/razor/cli/navigate.rb
@@ -214,11 +214,16 @@ module Razor::CLI
 
     private
     def cmd_schema(cmd_name)
-      cmd = json_get(@cmd_url)
-      cmd['schema'] or raise VersionCompatibilityError, 'Server must supply the expected datatypes for command arguments'
+      begin
+        json_get(@cmd_url)['schema']
+      rescue RestClient::ResourceNotFound => _
+        raise VersionCompatibilityError, 'Server must supply the expected datatypes for command arguments; use `--json` or upgrade razor-server'
+      end
     end
 
     def arg_type(cmd_name, arg_name)
+      # Short-circuit to allow this as a work-around for backwards compatibility.
+      return nil if arg_name == 'json'
       cmd = cmd_schema(cmd_name)
       cmd && cmd[arg_name] && cmd[arg_name]['type'] or nil
     end


### PR DESCRIPTION
Currently, razor-client version 0.15.0 cannot run commands with
versions of razor-server prior to 0.15.0, yielding an unexpected
404 from all commands.

So this change is twofold:
1) Supply a nice message when versions are incompatible, and
2) Allow `--json` as a way to bypass this incompatibility.

Fixes https://tickets.puppetlabs.com/browse/RAZOR-278
