### PR TITLE
`razor-client` cannot install on Ruby < 1.9.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,8 @@ source 'https://rubygems.org'
 # mime-types is a dependency of rest-client. We need to explicitly depend
 # on it and pin its version to make sure this works with Ruby 1.8.7
 gem 'mime-types', '< 2.0'
-gem 'rest-client'
+# `rest-client` adds an undesirable dependency on Ruby >= 1.9.2 in version 1.7.0.
+gem 'rest-client', '< 1.7'
 gem 'command_line_reporter', '>=3.0'
 
 group :doc do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,7 +44,7 @@ DEPENDENCIES
   mime-types (< 2.0)
   rack-test
   rake
-  rest-client
+  rest-client (< 1.7)
   rspec (~> 2.13.0)
   rspec-core (~> 2.13.1)
   rspec-expectations (~> 2.13.0)

--- a/razor-client.gemspec
+++ b/razor-client.gemspec
@@ -24,7 +24,8 @@ Gem::Specification.new do |spec|
   # on it and pin its version to make sure the gem works with Ruby 1.8.7
   spec.add_dependency "mime-types", '< 2.0'
   spec.add_dependency "multi_json"
-  spec.add_dependency "rest-client"
+  # `rest-client` adds an undesirable dependency on Ruby >= 1.9.2 in version 1.7.0.
+  spec.add_dependency "rest-client", '< 1.7'
   spec.add_dependency "command_line_reporter", '~> 3.0'
 
   spec.add_development_dependency "bundler", "~> 1.3"


### PR DESCRIPTION
razor-client had a versionless dependency on the rest-client gem. Previously,
rest-client 1.6.8 would work with Ruby >= 0. Today, rest-client issued a new
release (1.7.0) that only works with Ruby >= 1.9.2.

The fix, since we need to support older versions of Ruby, is to pin the
rest-client gem to versions prior to 1.7.

Fixes https://tickets.puppetlabs.com/browse/RAZOR-342
