### PR TITLE
Remember basic auth info from request to request.

### DIFF
--- a/lib/razor/cli/navigate.rb
+++ b/lib/razor/cli/navigate.rb
@@ -73,7 +73,6 @@ module Razor::CLI
         url = cmd["id"]
         if @doc_url
           url          = URI.parse(url.to_s)
-          url.userinfo = @doc_url.userinfo
         end
 
         if show_command_help?
@@ -156,7 +155,6 @@ module Razor::CLI
         url = obj["id"]
         if @doc_url
           url          = URI.parse(url.to_s)
-          url.userinfo = @doc_url.userinfo
         end
 
         @doc = json_get(url)
@@ -195,8 +193,6 @@ module Razor::CLI
     end
 
     def json_get(url, headers = {})
-      url = URI.parse(url.to_s)
-      url.userinfo = @userinfo
       response = get(url,headers.merge(:accept => :json))
       unless response.headers[:content_type] =~ /application\/json/
         raise "Received content type #{response.headers[:content_type]}"


### PR DESCRIPTION
Basic authentication does not work properly in razor-client-0.15.1.  

When I export `RAZOR_API` with credentials:

``` bash
export RAZOR_API=http://username:password@localhost/api
```

and I run a command like `create-repo`:

``` bash
razor create-repo --name=ubuntu-14.04 --iso-url file:///home/vagrant/mini.iso --task ubuntu
```

it is able to access the main `/api` URL, but the subsequent request to `/api/commands/create-repo` fails with `401 Unauthorized`.

After taking a quick look at the source, it would appear that the basic authentication credentials are not being properly inserted into URLs obtained from the API.  The initial call to the API succeeds, but all subsequent calls to URLs returned by the API fail.

This PR is a quick hack to get basic authentication working.  I can confirm that things now work properly whether or not I have basic authentication enabled for the Razor server.

There's probably a much more elegant way of doing this, so feel free to reject this PR, but I thought I'd submit it anyway.

It works by caching the `userinfo` of the first request to the API.  All subsequent API requests have the `userinfo` property set to that cached data (or to `nil`, if there are no credentials specified in the URL).
