### PR TITLE
Support curl-style '-k' (--insecure) flag / fix basic authentication

### DIFF
--- a/bin/razor
+++ b/bin/razor
@@ -61,6 +61,10 @@ rescue SocketError, Errno::ECONNREFUSED => e
   puts "Error: Could not connect to the server at #{parse.api_url}"
   puts "       #{e}\n"
   die
+rescue RestClient::SSLCertificateNotVerified
+  puts "Error: SSL certificate could not be verified against known CA certificates."
+  puts "       To turn off verification, use the -k or --insecure option."
+  die
 rescue RestClient::Exception => e
   r = e.response
   unexpected_error(e) if r.nil?

--- a/lib/razor/cli/parse.rb
+++ b/lib/razor/cli/parse.rb
@@ -26,6 +26,10 @@ module Razor::CLI
           @format = 'short'
         end
 
+        opts.on "-k", "--insecure", "Allow SSL connections without verified certificates" do
+	  @verify_ssl = false
+	end
+
         opts.on "-u", "--url URL",
           "The full Razor API URL, can also be set\n" + " "*37 +
           "with the RAZOR_API environment variable\n" + " "*37 +
@@ -105,12 +109,17 @@ ERR
       !!@dump
     end
 
+    def verify_ssl?
+      !!@verify_ssl
+    end
+
     attr_reader :api_url, :format, :args
 
     def initialize(args)
       parse_and_set_api_url(ENV["RAZOR_API"] || DEFAULT_RAZOR_API, :env)
       @args = args.dup
       @format = 'short'
+      @verify_ssl = true
       @args = get_optparse.order(@args)
       @args = set_help_vars(@args)
       if @args == ['version'] or @show_version

--- a/spec/cli/parse_spec.rb
+++ b/spec/cli/parse_spec.rb
@@ -19,6 +19,7 @@ describe Razor::CLI::Parse do
   describe "#new" do
     context "with no arguments" do
       it {parse.show_help?.should be true}
+      it {parse.verify_ssl?.should be true}
     end
 
     context "with a '-h'" do
@@ -58,6 +59,14 @@ describe Razor::CLI::Parse do
       it "should terminate with an error if an invalid URL is provided" do
         expect{parse('-u','not valid url')}.to raise_error(Razor::CLI::InvalidURIError)
       end
+    end
+
+    context "with a '-k'" do
+      it {parse("-k").verify_ssl?.should be false}
+    end
+
+    context "with a '--insecure'" do
+      it {parse("--insecure").verify_ssl?.should be false}
     end
 
     context "with ENV RAZOR_API set" do


### PR DESCRIPTION
This pull request adds the `-k` / `--insecure` option to `razor-client`, allowing SSL verification errors to be ignored.  This is useful if, for instance, one is testing with a self-signed certificate.

You'll notice that, to support this flag, I had to use `RestClient::Resource.new` in `navigate.rb`.  Hence, I added the `create_resource` method to reduce duplication.  The constructor for `Resource` is capable of taking the HTTP basic authentication credentials, so this pull request effectively obviates my previous one.

The only catch is testing.  I don't see a way of testing the `--insecure` option.  VCR deals with HTTP, and not SSL sockets -- there is no way to record the SSL certificate returned by the server in a VCR cassette.

Hence, I added tests to `parse_spec.rb`, but couldn't find a good way to test the actual behaviour of the `--insecure` option.  Informally, I can confirm it works fine on my system when dealing with unverified certificates.

Also, there is still the issue of the one failing test (the "userinfo" test) from my previous PR.  The constructor caches the HTTP username and password of the initial request, and `create_resource` sets the username and password automatically for all subsequent API calls.  Is the intent for `@doc_url` to point to the last API call made?  If so, I can amend `create_resource` to simply build a `URI` object, set its userinfo, and assign it to `@doc_url`.  This should make the test pass.
