### PR TITLE
Handle = in names

### DIFF
--- a/spec/cli/navigate_spec.rb
+++ b/spec/cli/navigate_spec.rb
@@ -38,7 +38,7 @@ describe Razor::CLI::Navigate do
   context "with invalid parameter", :vcr do
     it "should fail with bad JSON" do
       nav = Razor::CLI::Parse.new(['create-broker', '--name', 'broker', '--type', 'puppet', '--configuration', 'not-json']).navigate
-      expect{nav.get_document}.to raise_error(ArgumentError, /Invalid JSON for argument 'configuration'/)
+      expect{nav.get_document}.to raise_error(ArgumentError, /Invalid object for argument 'configuration'/)
     end
 
     it "should fail with malformed argument" do
@@ -107,13 +107,13 @@ describe Razor::CLI::Navigate do
         nav = Razor::CLI::Parse.new(['create-broker', '--name', 'broker2', '--broker-type', 'puppet',
                                      '--configuration', '["server"]',
                                      '--configuration', 'environment=production']).navigate
-        expect {nav.get_document}.to raise_error(ArgumentError, "Cannot handle mixed types for argument configuration")
+        expect {nav.get_document}.to raise_error(ArgumentError, "Invalid object for argument 'configuration'")
       end
       it "should fail with mixed types (hash then array)" do
         nav = Razor::CLI::Parse.new(['create-broker', '--name', 'broker3', '--broker-type', 'puppet',
                                      '--configuration', 'environment=production',
                                      '--configuration', '["server"]']).navigate
-        expect {nav.get_document}.to raise_error(ArgumentError, "Cannot handle mixed types for argument configuration")
+        expect {nav.get_document}.to raise_error(ArgumentError, "Invalid object for argument 'configuration'")
       end
     end
   end
@@ -123,6 +123,10 @@ describe Razor::CLI::Navigate do
       Razor::CLI::Parse.new(['create-repo', '--name', 'separate with spaces', '--url', 'http://url.com/some.iso', '--task', 'noop']).navigate.get_document
       Razor::CLI::Parse.new(['create-repo', '--name="double-quote with spaces"', '--url', 'http://url.com/some.iso', '--task', 'noop']).navigate.get_document
       Razor::CLI::Parse.new(['create-repo', '--name=\'single-quote with spaces\'', '--url', 'http://url.com/some.iso', '--task', 'noop']).navigate.get_document
+    end
+
+    it "should allow '=' in string" do
+      Razor::CLI::Parse.new(['create-repo', '--name=\'with=equals\'', '--url', 'http://url.com/some.iso', '--task', 'noop']).navigate.get_document['name'].should =~ /with=equals/
     end
   end
 

--- a/spec/fixtures/vcr/Razor_CLI_Navigate/argument_formatting/should_allow_in_string.yml
+++ b/spec/fixtures/vcr/Razor_CLI_Navigate/argument_formatting/should_allow_in_string.yml
@@ -1,0 +1,322 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:8080/api
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json;charset=utf-8
+      Content-Length:
+      - '4981'
+      Date:
+      - Thu, 14 Aug 2014 21:10:25 GMT
+    body:
+      encoding: US-ASCII
+      string: '{"commands":[{"name":"add-policy-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/add-policy-tag","id":"http://localhost:8080/api/commands/add-policy-tag"},{"name":"create-broker","rel":"http://api.puppetlabs.com/razor/v1/commands/create-broker","id":"http://localhost:8080/api/commands/create-broker"},{"name":"create-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/create-policy","id":"http://localhost:8080/api/commands/create-policy"},{"name":"create-repo","rel":"http://api.puppetlabs.com/razor/v1/commands/create-repo","id":"http://localhost:8080/api/commands/create-repo"},{"name":"create-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/create-tag","id":"http://localhost:8080/api/commands/create-tag"},{"name":"create-task","rel":"http://api.puppetlabs.com/razor/v1/commands/create-task","id":"http://localhost:8080/api/commands/create-task"},{"name":"delete-broker","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-broker","id":"http://localhost:8080/api/commands/delete-broker"},{"name":"delete-node","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-node","id":"http://localhost:8080/api/commands/delete-node"},{"name":"delete-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-policy","id":"http://localhost:8080/api/commands/delete-policy"},{"name":"delete-repo","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-repo","id":"http://localhost:8080/api/commands/delete-repo"},{"name":"delete-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-tag","id":"http://localhost:8080/api/commands/delete-tag"},{"name":"disable-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/disable-policy","id":"http://localhost:8080/api/commands/disable-policy"},{"name":"enable-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/enable-policy","id":"http://localhost:8080/api/commands/enable-policy"},{"name":"modify-node-metadata","rel":"http://api.puppetlabs.com/razor/v1/commands/modify-node-metadata","id":"http://localhost:8080/api/commands/modify-node-metadata"},{"name":"modify-policy-max-count","rel":"http://api.puppetlabs.com/razor/v1/commands/modify-policy-max-count","id":"http://localhost:8080/api/commands/modify-policy-max-count"},{"name":"move-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/move-policy","id":"http://localhost:8080/api/commands/move-policy"},{"name":"reboot-node","rel":"http://api.puppetlabs.com/razor/v1/commands/reboot-node","id":"http://localhost:8080/api/commands/reboot-node"},{"name":"register-node","rel":"http://api.puppetlabs.com/razor/v1/commands/register-node","id":"http://localhost:8080/api/commands/register-node"},{"name":"reinstall-node","rel":"http://api.puppetlabs.com/razor/v1/commands/reinstall-node","id":"http://localhost:8080/api/commands/reinstall-node"},{"name":"remove-node-metadata","rel":"http://api.puppetlabs.com/razor/v1/commands/remove-node-metadata","id":"http://localhost:8080/api/commands/remove-node-metadata"},{"name":"remove-policy-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/remove-policy-tag","id":"http://localhost:8080/api/commands/remove-policy-tag"},{"name":"set-node-desired-power-state","rel":"http://api.puppetlabs.com/razor/v1/commands/set-node-desired-power-state","id":"http://localhost:8080/api/commands/set-node-desired-power-state"},{"name":"set-node-hw-info","rel":"http://api.puppetlabs.com/razor/v1/commands/set-node-hw-info","id":"http://localhost:8080/api/commands/set-node-hw-info"},{"name":"set-node-ipmi-credentials","rel":"http://api.puppetlabs.com/razor/v1/commands/set-node-ipmi-credentials","id":"http://localhost:8080/api/commands/set-node-ipmi-credentials"},{"name":"update-node-metadata","rel":"http://api.puppetlabs.com/razor/v1/commands/update-node-metadata","id":"http://localhost:8080/api/commands/update-node-metadata"},{"name":"update-tag-rule","rel":"http://api.puppetlabs.com/razor/v1/commands/update-tag-rule","id":"http://localhost:8080/api/commands/update-tag-rule"}],"collections":[{"name":"brokers","rel":"http://api.puppetlabs.com/razor/v1/collections/brokers","id":"http://localhost:8080/api/collections/brokers"},{"name":"repos","rel":"http://api.puppetlabs.com/razor/v1/collections/repos","id":"http://localhost:8080/api/collections/repos"},{"name":"tags","rel":"http://api.puppetlabs.com/razor/v1/collections/tags","id":"http://localhost:8080/api/collections/tags"},{"name":"policies","rel":"http://api.puppetlabs.com/razor/v1/collections/policies","id":"http://localhost:8080/api/collections/policies"},{"name":"nodes","rel":"http://api.puppetlabs.com/razor/v1/collections/nodes","id":"http://localhost:8080/api/collections/nodes"},{"name":"tasks","rel":"http://api.puppetlabs.com/razor/v1/collections/tasks","id":"http://localhost:8080/api/collections/tasks"},{"name":"commands","rel":"http://api.puppetlabs.com/razor/v1/collections/commands","id":"http://localhost:8080/api/collections/commands"}],"version":{"server":"v0.15.0-26-gfffaba4-dirty"}}'
+    http_version:
+  recorded_at: Thu, 14 Aug 2014 21:10:25 GMT
+- request:
+    method: get
+    uri: http://localhost:8080/api/commands/create-repo
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Etag:
+      - '"server-version-v0.15.0-26-gfffaba4-dirty"'
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json;charset=utf-8
+      Content-Length:
+      - '3240'
+      Date:
+      - Thu, 14 Aug 2014 21:10:25 GMT
+    body:
+      encoding: US-ASCII
+      string: '{"name":"create-repo","help":{"full":"# SYNOPSIS\nCreate a new repository,
+        from an ISO image or a URL\n\n# DESCRIPTION\nCreate a new repository, which
+        can either contain the content to install a\nnode, or simply point to an existing
+        online repository by URL.\n\n# Access Control\n\nThis command''s access control
+        pattern: `commands:create-repo:%{name}`\n\nWords surrounded by `%{...}` are
+        substitutions from the input data: typically\nthe name of the object being
+        modified, or some other critical detail, these\nallow roles to be granted
+        partial access to modify the system.\n\nFor more detail on how the permission
+        strings are structured and work, you can\nsee the [Shiro Permissions documentation][shiro].  That
+        pattern is expanded\nand then a permission check applied to it, before the
+        command is authorized.\n\nThese checks only apply if security is enabled in
+        the Razor configuration\nfile; on this server security is currently disabled.\n\n[shiro]:
+        http://shiro.apache.org/permissions.html\n\n# Attributes\n\n * name\n   -
+        The name of the repository.\n   - This attribute is required.\n   - It must
+        be of type string.\n   - It must be between 1 and 250 in length.\n\n * url\n   -
+        The URL of the remote repository to use.\n   - It must be of type string.\n   -
+        If present, iso-url must not be present.\n   - It must be between 1 and 1000
+        in length.\n\n * iso-url\n   - The URL of the ISO image to download and unpack
+        to create the\n     repository.  This can be an HTTP or HTTPS URL, or it can
+        be a\n     file URL.\n     \n     In the latter case, the file path is interpreted
+        as a path on the\n     Razor server, rather than a path on the client.  This
+        requires that\n     you manually place the ISO image on the server before
+        invoking the\n     command.\n   - It must be of type string.\n   - If present,
+        url must not be present.\n   - It must be between 1 and 1000 in length.\n\n
+        * task\n   - The name of the task associated with this repository.  This is
+        used to\n     install nodes that match a policy using this repository; generally
+        it\n     should match the OS that the URL or ISO-URL attributes point to.\n   -
+        This attribute is required.\n   - It must be of type string.\n\n# EXAMPLES\n\n  Create
+        a repository from an ISO image, which will be downloaded and unpacked\n  by
+        the razor-server in the background:\n  \n      {\n        \"name\":    \"fedora19\",\n        \"iso-url\":
+        \"http://example.com/Fedora-19-x86_64-DVD.iso\"\n        \"task\":    \"fedora\"\n      }\n  \n  You
+        can also unpack an ISO image from a file *on the server*; this does not\n  upload
+        the file from the client:\n      {\n        \"name\":    \"fedora19\",\n        \"iso-url\":
+        \"file:///tmp/Fedora-19-x86_64-DVD.iso\"\n        \"task\":    \"fedora\"\n      }\n  \n  Finally,
+        you can provide a `url` property when you create the repository;\n  this form
+        is merely a pointer to a resource somewhere and nothing will be\n  downloaded
+        onto the Razor server:\n  \n      {\n        \"name\": \"fedora19\",\n        \"url\":  \"http://mirrors.n-ix.net/fedora/linux/releases/19/Fedora/x86_64/os/\"\n        \"task\":
+        \"fedora\"\n      }\n"},"schema":{"name":{"type":"string"},"url":{"type":"string"},"iso-url":{"type":"string"},"task":{"type":"string"}}}'
+    http_version:
+  recorded_at: Thu, 14 Aug 2014 21:10:25 GMT
+- request:
+    method: get
+    uri: http://localhost:8080/api/commands/create-repo
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Etag:
+      - '"server-version-v0.15.0-26-gfffaba4-dirty"'
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json;charset=utf-8
+      Content-Length:
+      - '3240'
+      Date:
+      - Thu, 14 Aug 2014 21:10:25 GMT
+    body:
+      encoding: US-ASCII
+      string: '{"name":"create-repo","help":{"full":"# SYNOPSIS\nCreate a new repository,
+        from an ISO image or a URL\n\n# DESCRIPTION\nCreate a new repository, which
+        can either contain the content to install a\nnode, or simply point to an existing
+        online repository by URL.\n\n# Access Control\n\nThis command''s access control
+        pattern: `commands:create-repo:%{name}`\n\nWords surrounded by `%{...}` are
+        substitutions from the input data: typically\nthe name of the object being
+        modified, or some other critical detail, these\nallow roles to be granted
+        partial access to modify the system.\n\nFor more detail on how the permission
+        strings are structured and work, you can\nsee the [Shiro Permissions documentation][shiro].  That
+        pattern is expanded\nand then a permission check applied to it, before the
+        command is authorized.\n\nThese checks only apply if security is enabled in
+        the Razor configuration\nfile; on this server security is currently disabled.\n\n[shiro]:
+        http://shiro.apache.org/permissions.html\n\n# Attributes\n\n * name\n   -
+        The name of the repository.\n   - This attribute is required.\n   - It must
+        be of type string.\n   - It must be between 1 and 250 in length.\n\n * url\n   -
+        The URL of the remote repository to use.\n   - It must be of type string.\n   -
+        If present, iso-url must not be present.\n   - It must be between 1 and 1000
+        in length.\n\n * iso-url\n   - The URL of the ISO image to download and unpack
+        to create the\n     repository.  This can be an HTTP or HTTPS URL, or it can
+        be a\n     file URL.\n     \n     In the latter case, the file path is interpreted
+        as a path on the\n     Razor server, rather than a path on the client.  This
+        requires that\n     you manually place the ISO image on the server before
+        invoking the\n     command.\n   - It must be of type string.\n   - If present,
+        url must not be present.\n   - It must be between 1 and 1000 in length.\n\n
+        * task\n   - The name of the task associated with this repository.  This is
+        used to\n     install nodes that match a policy using this repository; generally
+        it\n     should match the OS that the URL or ISO-URL attributes point to.\n   -
+        This attribute is required.\n   - It must be of type string.\n\n# EXAMPLES\n\n  Create
+        a repository from an ISO image, which will be downloaded and unpacked\n  by
+        the razor-server in the background:\n  \n      {\n        \"name\":    \"fedora19\",\n        \"iso-url\":
+        \"http://example.com/Fedora-19-x86_64-DVD.iso\"\n        \"task\":    \"fedora\"\n      }\n  \n  You
+        can also unpack an ISO image from a file *on the server*; this does not\n  upload
+        the file from the client:\n      {\n        \"name\":    \"fedora19\",\n        \"iso-url\":
+        \"file:///tmp/Fedora-19-x86_64-DVD.iso\"\n        \"task\":    \"fedora\"\n      }\n  \n  Finally,
+        you can provide a `url` property when you create the repository;\n  this form
+        is merely a pointer to a resource somewhere and nothing will be\n  downloaded
+        onto the Razor server:\n  \n      {\n        \"name\": \"fedora19\",\n        \"url\":  \"http://mirrors.n-ix.net/fedora/linux/releases/19/Fedora/x86_64/os/\"\n        \"task\":
+        \"fedora\"\n      }\n"},"schema":{"name":{"type":"string"},"url":{"type":"string"},"iso-url":{"type":"string"},"task":{"type":"string"}}}'
+    http_version:
+  recorded_at: Thu, 14 Aug 2014 21:10:25 GMT
+- request:
+    method: get
+    uri: http://localhost:8080/api/commands/create-repo
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Etag:
+      - '"server-version-v0.15.0-26-gfffaba4-dirty"'
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json;charset=utf-8
+      Content-Length:
+      - '3240'
+      Date:
+      - Thu, 14 Aug 2014 21:10:25 GMT
+    body:
+      encoding: US-ASCII
+      string: '{"name":"create-repo","help":{"full":"# SYNOPSIS\nCreate a new repository,
+        from an ISO image or a URL\n\n# DESCRIPTION\nCreate a new repository, which
+        can either contain the content to install a\nnode, or simply point to an existing
+        online repository by URL.\n\n# Access Control\n\nThis command''s access control
+        pattern: `commands:create-repo:%{name}`\n\nWords surrounded by `%{...}` are
+        substitutions from the input data: typically\nthe name of the object being
+        modified, or some other critical detail, these\nallow roles to be granted
+        partial access to modify the system.\n\nFor more detail on how the permission
+        strings are structured and work, you can\nsee the [Shiro Permissions documentation][shiro].  That
+        pattern is expanded\nand then a permission check applied to it, before the
+        command is authorized.\n\nThese checks only apply if security is enabled in
+        the Razor configuration\nfile; on this server security is currently disabled.\n\n[shiro]:
+        http://shiro.apache.org/permissions.html\n\n# Attributes\n\n * name\n   -
+        The name of the repository.\n   - This attribute is required.\n   - It must
+        be of type string.\n   - It must be between 1 and 250 in length.\n\n * url\n   -
+        The URL of the remote repository to use.\n   - It must be of type string.\n   -
+        If present, iso-url must not be present.\n   - It must be between 1 and 1000
+        in length.\n\n * iso-url\n   - The URL of the ISO image to download and unpack
+        to create the\n     repository.  This can be an HTTP or HTTPS URL, or it can
+        be a\n     file URL.\n     \n     In the latter case, the file path is interpreted
+        as a path on the\n     Razor server, rather than a path on the client.  This
+        requires that\n     you manually place the ISO image on the server before
+        invoking the\n     command.\n   - It must be of type string.\n   - If present,
+        url must not be present.\n   - It must be between 1 and 1000 in length.\n\n
+        * task\n   - The name of the task associated with this repository.  This is
+        used to\n     install nodes that match a policy using this repository; generally
+        it\n     should match the OS that the URL or ISO-URL attributes point to.\n   -
+        This attribute is required.\n   - It must be of type string.\n\n# EXAMPLES\n\n  Create
+        a repository from an ISO image, which will be downloaded and unpacked\n  by
+        the razor-server in the background:\n  \n      {\n        \"name\":    \"fedora19\",\n        \"iso-url\":
+        \"http://example.com/Fedora-19-x86_64-DVD.iso\"\n        \"task\":    \"fedora\"\n      }\n  \n  You
+        can also unpack an ISO image from a file *on the server*; this does not\n  upload
+        the file from the client:\n      {\n        \"name\":    \"fedora19\",\n        \"iso-url\":
+        \"file:///tmp/Fedora-19-x86_64-DVD.iso\"\n        \"task\":    \"fedora\"\n      }\n  \n  Finally,
+        you can provide a `url` property when you create the repository;\n  this form
+        is merely a pointer to a resource somewhere and nothing will be\n  downloaded
+        onto the Razor server:\n  \n      {\n        \"name\": \"fedora19\",\n        \"url\":  \"http://mirrors.n-ix.net/fedora/linux/releases/19/Fedora/x86_64/os/\"\n        \"task\":
+        \"fedora\"\n      }\n"},"schema":{"name":{"type":"string"},"url":{"type":"string"},"iso-url":{"type":"string"},"task":{"type":"string"}}}'
+    http_version:
+  recorded_at: Thu, 14 Aug 2014 21:10:26 GMT
+- request:
+    method: post
+    uri: http://localhost:8080/api/commands/create-repo
+    body:
+      encoding: UTF-8
+      string: '{"name":"''with=equals''","url":"http://url.com/some.iso","task":"noop"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '70'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json;charset=utf-8
+      Content-Length:
+      - '219'
+      Date:
+      - Thu, 14 Aug 2014 21:10:25 GMT
+    body:
+      encoding: US-ASCII
+      string: '{"spec":"http://api.puppetlabs.com/razor/v1/collections/repos/member","id":"http://localhost:8080/api/collections/repos/''with=equals''","name":"''with=equals''","command":"http://localhost:8080/api/collections/commands/1"}'
+    http_version:
+  recorded_at: Thu, 14 Aug 2014 21:10:26 GMT
+- request:
+    method: get
+    uri: http://localhost:8080/api/collections/repos/'with=equals'
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json;charset=utf-8
+      Content-Length:
+      - '353'
+      Date:
+      - Thu, 14 Aug 2014 21:10:25 GMT
+    body:
+      encoding: US-ASCII
+      string: '{"spec":"http://api.puppetlabs.com/razor/v1/collections/repos/member","id":"http://localhost:8080/api/collections/repos/''with=equals''","name":"''with=equals''","iso_url":null,"url":"http://url.com/some.iso","task":{"spec":"http://api.puppetlabs.com/razor/v1/collections/tasks/member","id":"http://localhost:8080/api/collections/tasks/noop","name":"noop"}}'
+    http_version:
+  recorded_at: Thu, 14 Aug 2014 21:10:26 GMT
+recorded_with: VCR 2.9.2

--- a/spec/fixtures/vcr/Razor_CLI_Navigate/with_multiple_arguments_with_same_name/combining_as_an_object/should_construct_a_json_object.yml
+++ b/spec/fixtures/vcr/Razor_CLI_Navigate/with_multiple_arguments_with_same_name/combining_as_an_object/should_construct_a_json_object.yml
@@ -25,14 +25,14 @@ http_interactions:
       Content-Type:
       - application/json;charset=utf-8
       Content-Length:
-      - '4982'
+      - '4981'
       Date:
-      - Fri, 16 May 2014 22:18:28 GMT
+      - Thu, 14 Aug 2014 20:49:46 GMT
     body:
       encoding: US-ASCII
-      string: '{"commands":[{"name":"add-policy-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/add-policy-tag","id":"http://localhost:8080/api/commands/add-policy-tag"},{"name":"create-broker","rel":"http://api.puppetlabs.com/razor/v1/commands/create-broker","id":"http://localhost:8080/api/commands/create-broker"},{"name":"create-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/create-policy","id":"http://localhost:8080/api/commands/create-policy"},{"name":"create-repo","rel":"http://api.puppetlabs.com/razor/v1/commands/create-repo","id":"http://localhost:8080/api/commands/create-repo"},{"name":"create-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/create-tag","id":"http://localhost:8080/api/commands/create-tag"},{"name":"create-task","rel":"http://api.puppetlabs.com/razor/v1/commands/create-task","id":"http://localhost:8080/api/commands/create-task"},{"name":"delete-broker","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-broker","id":"http://localhost:8080/api/commands/delete-broker"},{"name":"delete-node","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-node","id":"http://localhost:8080/api/commands/delete-node"},{"name":"delete-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-policy","id":"http://localhost:8080/api/commands/delete-policy"},{"name":"delete-repo","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-repo","id":"http://localhost:8080/api/commands/delete-repo"},{"name":"delete-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-tag","id":"http://localhost:8080/api/commands/delete-tag"},{"name":"disable-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/disable-policy","id":"http://localhost:8080/api/commands/disable-policy"},{"name":"enable-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/enable-policy","id":"http://localhost:8080/api/commands/enable-policy"},{"name":"modify-node-metadata","rel":"http://api.puppetlabs.com/razor/v1/commands/modify-node-metadata","id":"http://localhost:8080/api/commands/modify-node-metadata"},{"name":"modify-policy-max-count","rel":"http://api.puppetlabs.com/razor/v1/commands/modify-policy-max-count","id":"http://localhost:8080/api/commands/modify-policy-max-count"},{"name":"move-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/move-policy","id":"http://localhost:8080/api/commands/move-policy"},{"name":"reboot-node","rel":"http://api.puppetlabs.com/razor/v1/commands/reboot-node","id":"http://localhost:8080/api/commands/reboot-node"},{"name":"register-node","rel":"http://api.puppetlabs.com/razor/v1/commands/register-node","id":"http://localhost:8080/api/commands/register-node"},{"name":"reinstall-node","rel":"http://api.puppetlabs.com/razor/v1/commands/reinstall-node","id":"http://localhost:8080/api/commands/reinstall-node"},{"name":"remove-node-metadata","rel":"http://api.puppetlabs.com/razor/v1/commands/remove-node-metadata","id":"http://localhost:8080/api/commands/remove-node-metadata"},{"name":"remove-policy-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/remove-policy-tag","id":"http://localhost:8080/api/commands/remove-policy-tag"},{"name":"set-node-desired-power-state","rel":"http://api.puppetlabs.com/razor/v1/commands/set-node-desired-power-state","id":"http://localhost:8080/api/commands/set-node-desired-power-state"},{"name":"set-node-hw-info","rel":"http://api.puppetlabs.com/razor/v1/commands/set-node-hw-info","id":"http://localhost:8080/api/commands/set-node-hw-info"},{"name":"set-node-ipmi-credentials","rel":"http://api.puppetlabs.com/razor/v1/commands/set-node-ipmi-credentials","id":"http://localhost:8080/api/commands/set-node-ipmi-credentials"},{"name":"update-node-metadata","rel":"http://api.puppetlabs.com/razor/v1/commands/update-node-metadata","id":"http://localhost:8080/api/commands/update-node-metadata"},{"name":"update-tag-rule","rel":"http://api.puppetlabs.com/razor/v1/commands/update-tag-rule","id":"http://localhost:8080/api/commands/update-tag-rule"}],"collections":[{"name":"brokers","rel":"http://api.puppetlabs.com/razor/v1/collections/brokers","id":"http://localhost:8080/api/collections/brokers"},{"name":"repos","rel":"http://api.puppetlabs.com/razor/v1/collections/repos","id":"http://localhost:8080/api/collections/repos"},{"name":"tags","rel":"http://api.puppetlabs.com/razor/v1/collections/tags","id":"http://localhost:8080/api/collections/tags"},{"name":"policies","rel":"http://api.puppetlabs.com/razor/v1/collections/policies","id":"http://localhost:8080/api/collections/policies"},{"name":"nodes","rel":"http://api.puppetlabs.com/razor/v1/collections/nodes","id":"http://localhost:8080/api/collections/nodes"},{"name":"tasks","rel":"http://api.puppetlabs.com/razor/v1/collections/tasks","id":"http://localhost:8080/api/collections/tasks"},{"name":"commands","rel":"http://api.puppetlabs.com/razor/v1/collections/commands","id":"http://localhost:8080/api/collections/commands"}],"version":{"server":"v0.14.1-113-g8b33d83-dirty"}}'
+      string: '{"commands":[{"name":"add-policy-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/add-policy-tag","id":"http://localhost:8080/api/commands/add-policy-tag"},{"name":"create-broker","rel":"http://api.puppetlabs.com/razor/v1/commands/create-broker","id":"http://localhost:8080/api/commands/create-broker"},{"name":"create-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/create-policy","id":"http://localhost:8080/api/commands/create-policy"},{"name":"create-repo","rel":"http://api.puppetlabs.com/razor/v1/commands/create-repo","id":"http://localhost:8080/api/commands/create-repo"},{"name":"create-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/create-tag","id":"http://localhost:8080/api/commands/create-tag"},{"name":"create-task","rel":"http://api.puppetlabs.com/razor/v1/commands/create-task","id":"http://localhost:8080/api/commands/create-task"},{"name":"delete-broker","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-broker","id":"http://localhost:8080/api/commands/delete-broker"},{"name":"delete-node","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-node","id":"http://localhost:8080/api/commands/delete-node"},{"name":"delete-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-policy","id":"http://localhost:8080/api/commands/delete-policy"},{"name":"delete-repo","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-repo","id":"http://localhost:8080/api/commands/delete-repo"},{"name":"delete-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-tag","id":"http://localhost:8080/api/commands/delete-tag"},{"name":"disable-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/disable-policy","id":"http://localhost:8080/api/commands/disable-policy"},{"name":"enable-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/enable-policy","id":"http://localhost:8080/api/commands/enable-policy"},{"name":"modify-node-metadata","rel":"http://api.puppetlabs.com/razor/v1/commands/modify-node-metadata","id":"http://localhost:8080/api/commands/modify-node-metadata"},{"name":"modify-policy-max-count","rel":"http://api.puppetlabs.com/razor/v1/commands/modify-policy-max-count","id":"http://localhost:8080/api/commands/modify-policy-max-count"},{"name":"move-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/move-policy","id":"http://localhost:8080/api/commands/move-policy"},{"name":"reboot-node","rel":"http://api.puppetlabs.com/razor/v1/commands/reboot-node","id":"http://localhost:8080/api/commands/reboot-node"},{"name":"register-node","rel":"http://api.puppetlabs.com/razor/v1/commands/register-node","id":"http://localhost:8080/api/commands/register-node"},{"name":"reinstall-node","rel":"http://api.puppetlabs.com/razor/v1/commands/reinstall-node","id":"http://localhost:8080/api/commands/reinstall-node"},{"name":"remove-node-metadata","rel":"http://api.puppetlabs.com/razor/v1/commands/remove-node-metadata","id":"http://localhost:8080/api/commands/remove-node-metadata"},{"name":"remove-policy-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/remove-policy-tag","id":"http://localhost:8080/api/commands/remove-policy-tag"},{"name":"set-node-desired-power-state","rel":"http://api.puppetlabs.com/razor/v1/commands/set-node-desired-power-state","id":"http://localhost:8080/api/commands/set-node-desired-power-state"},{"name":"set-node-hw-info","rel":"http://api.puppetlabs.com/razor/v1/commands/set-node-hw-info","id":"http://localhost:8080/api/commands/set-node-hw-info"},{"name":"set-node-ipmi-credentials","rel":"http://api.puppetlabs.com/razor/v1/commands/set-node-ipmi-credentials","id":"http://localhost:8080/api/commands/set-node-ipmi-credentials"},{"name":"update-node-metadata","rel":"http://api.puppetlabs.com/razor/v1/commands/update-node-metadata","id":"http://localhost:8080/api/commands/update-node-metadata"},{"name":"update-tag-rule","rel":"http://api.puppetlabs.com/razor/v1/commands/update-tag-rule","id":"http://localhost:8080/api/commands/update-tag-rule"}],"collections":[{"name":"brokers","rel":"http://api.puppetlabs.com/razor/v1/collections/brokers","id":"http://localhost:8080/api/collections/brokers"},{"name":"repos","rel":"http://api.puppetlabs.com/razor/v1/collections/repos","id":"http://localhost:8080/api/collections/repos"},{"name":"tags","rel":"http://api.puppetlabs.com/razor/v1/collections/tags","id":"http://localhost:8080/api/collections/tags"},{"name":"policies","rel":"http://api.puppetlabs.com/razor/v1/collections/policies","id":"http://localhost:8080/api/collections/policies"},{"name":"nodes","rel":"http://api.puppetlabs.com/razor/v1/collections/nodes","id":"http://localhost:8080/api/collections/nodes"},{"name":"tasks","rel":"http://api.puppetlabs.com/razor/v1/collections/tasks","id":"http://localhost:8080/api/collections/tasks"},{"name":"commands","rel":"http://api.puppetlabs.com/razor/v1/collections/commands","id":"http://localhost:8080/api/collections/commands"}],"version":{"server":"v0.15.0-26-gfffaba4-dirty"}}'
     http_version:
-  recorded_at: Fri, 16 May 2014 22:18:28 GMT
+  recorded_at: Thu, 14 Aug 2014 20:49:46 GMT
 - request:
     method: get
     uri: http://localhost:8080/api/commands/create-broker
@@ -54,23 +54,23 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       Etag:
-      - '"server-version-v0.14.1-113-g8b33d83-dirty"'
+      - '"server-version-v0.15.0-26-gfffaba4-dirty"'
       X-Content-Type-Options:
       - nosniff
       Content-Type:
       - application/json;charset=utf-8
       Content-Length:
-      - '2496'
+      - '2568'
       Date:
-      - Fri, 16 May 2014 22:18:28 GMT
+      - Thu, 14 Aug 2014 20:49:46 GMT
     body:
       encoding: US-ASCII
       string: '{"name":"create-broker","help":{"full":"# SYNOPSIS\nCreate a new broker
         configuration for hand-off of installed nodes\n\n# DESCRIPTION\nCreate a new
         broker configuration.  Brokers are responsible for handing a node\noff to
         a config management system, such as Puppet or Chef.  In cases where you\nhave
-        no configuration management system, you can use the `noop` broker.\n\n\n#
-        Access Control\n\nThis command''s access control pattern: `commands:create-broker:%{name}`\n\nWords
+        no configuration management system, you can use the `noop` broker.\n\n# Access
+        Control\n\nThis command''s access control pattern: `commands:create-broker:%{name}`\n\nWords
         surrounded by `%{...}` are substitutions from the input data: typically\nthe
         name of the object being modified, or some other critical detail, these\nallow
         roles to be granted partial access to modify the system.\n\nFor more detail
@@ -80,23 +80,24 @@ http_interactions:
         apply if security is enabled in the Razor configuration\nfile; on this server
         security is currently disabled.\n\n[shiro]: http://shiro.apache.org/permissions.html\n\n#
         Attributes\n\n * name\n   - The name of the broker, as it will be referenced
-        within Razor.\n   This is the name that you supply to, eg, `create-policy`
-        to specify\n   which broker the node will be handed off via after installation.\n   -
-        This attribute is required\n   - It must be of type string.\n   - It must
-        be between 1 and 250 in length.\n\n * broker-type\n   - The broker type that
-        this broker is created from.  The available\n   broker types on your server
-        are:\n        - chef\n    - noop\n    - puppet-pe\n    - puppet\n   - This
-        attribute is required\n   - It must be of type string.\n   - It must match
+        within Razor.\n     This is the name that you supply to, eg, `create-policy`
+        to specify\n     which broker the node will be handed off via after installation.\n   -
+        This attribute is required.\n   - It must be of type string.\n   - It must
+        be between 1 and 250 in length.\n\n * broker-type\n   - The broker type from
+        which this broker is created.  The available\n     broker types on your server
+        are:\n     - chef\n     - noop\n     - puppet-pe\n     - puppet\n   - This
+        attribute is required.\n   - It must be of type string.\n   - It must match
         the name of an existing broker type.\n\n * configuration\n   - The configuration
-        for the broker.  The acceptable values here are\n   determined by the `broker-type`
-        selected.  In general this has\n   settings like which server to contact,
-        and other configuration\n   related to handing on the newly installed system
-        to the final\n   configuration management system.\n   - It must be of type
-        object.\n   \n   \n\n\n\n# EXAMPLES\n  Creating a simple Puppet broker:\n  \n  {\n    \"name\":
-        \"puppet\",\n    \"configuration\": {\n       \"server\":      \"puppet.example.org\",\n       \"environment\":
-        \"production\"\n    },\n    \"broker-type\": \"puppet\"\n  }\n\n"},"schema":{"name":{"type":"string"},"broker-type":{"type":"string"},"configuration":{"type":"object"}}}'
+        for the broker.  The acceptable values here are\n     determined by the `broker-type`
+        selected.  In general this has\n     settings like which server to contact,
+        and other configuration\n     related to handing on the newly installed system
+        to the final\n     configuration management system.\n     \n     This attribute
+        can be abbreviated as `c` for convenience.\n   - It must be of type object.\n\n#
+        EXAMPLES\n\n  Creating a simple Puppet broker:\n  \n  {\n    \"name\": \"puppet\",\n    \"configuration\":
+        {\n       \"server\":      \"puppet.example.org\",\n       \"environment\":
+        \"production\"\n    },\n    \"broker-type\": \"puppet\"\n  }\n"},"schema":{"name":{"type":"string"},"broker-type":{"type":"string"},"configuration":{"type":"object"}}}'
     http_version:
-  recorded_at: Fri, 16 May 2014 22:18:28 GMT
+  recorded_at: Thu, 14 Aug 2014 20:49:46 GMT
 - request:
     method: get
     uri: http://localhost:8080/api/commands/create-broker
@@ -118,23 +119,23 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       Etag:
-      - '"server-version-v0.14.1-113-g8b33d83-dirty"'
+      - '"server-version-v0.15.0-26-gfffaba4-dirty"'
       X-Content-Type-Options:
       - nosniff
       Content-Type:
       - application/json;charset=utf-8
       Content-Length:
-      - '2496'
+      - '2568'
       Date:
-      - Fri, 16 May 2014 22:18:28 GMT
+      - Thu, 14 Aug 2014 20:49:46 GMT
     body:
       encoding: US-ASCII
       string: '{"name":"create-broker","help":{"full":"# SYNOPSIS\nCreate a new broker
         configuration for hand-off of installed nodes\n\n# DESCRIPTION\nCreate a new
         broker configuration.  Brokers are responsible for handing a node\noff to
         a config management system, such as Puppet or Chef.  In cases where you\nhave
-        no configuration management system, you can use the `noop` broker.\n\n\n#
-        Access Control\n\nThis command''s access control pattern: `commands:create-broker:%{name}`\n\nWords
+        no configuration management system, you can use the `noop` broker.\n\n# Access
+        Control\n\nThis command''s access control pattern: `commands:create-broker:%{name}`\n\nWords
         surrounded by `%{...}` are substitutions from the input data: typically\nthe
         name of the object being modified, or some other critical detail, these\nallow
         roles to be granted partial access to modify the system.\n\nFor more detail
@@ -144,23 +145,154 @@ http_interactions:
         apply if security is enabled in the Razor configuration\nfile; on this server
         security is currently disabled.\n\n[shiro]: http://shiro.apache.org/permissions.html\n\n#
         Attributes\n\n * name\n   - The name of the broker, as it will be referenced
-        within Razor.\n   This is the name that you supply to, eg, `create-policy`
-        to specify\n   which broker the node will be handed off via after installation.\n   -
-        This attribute is required\n   - It must be of type string.\n   - It must
-        be between 1 and 250 in length.\n\n * broker-type\n   - The broker type that
-        this broker is created from.  The available\n   broker types on your server
-        are:\n        - chef\n    - noop\n    - puppet-pe\n    - puppet\n   - This
-        attribute is required\n   - It must be of type string.\n   - It must match
+        within Razor.\n     This is the name that you supply to, eg, `create-policy`
+        to specify\n     which broker the node will be handed off via after installation.\n   -
+        This attribute is required.\n   - It must be of type string.\n   - It must
+        be between 1 and 250 in length.\n\n * broker-type\n   - The broker type from
+        which this broker is created.  The available\n     broker types on your server
+        are:\n     - chef\n     - noop\n     - puppet-pe\n     - puppet\n   - This
+        attribute is required.\n   - It must be of type string.\n   - It must match
         the name of an existing broker type.\n\n * configuration\n   - The configuration
-        for the broker.  The acceptable values here are\n   determined by the `broker-type`
-        selected.  In general this has\n   settings like which server to contact,
-        and other configuration\n   related to handing on the newly installed system
-        to the final\n   configuration management system.\n   - It must be of type
-        object.\n   \n   \n\n\n\n# EXAMPLES\n  Creating a simple Puppet broker:\n  \n  {\n    \"name\":
-        \"puppet\",\n    \"configuration\": {\n       \"server\":      \"puppet.example.org\",\n       \"environment\":
-        \"production\"\n    },\n    \"broker-type\": \"puppet\"\n  }\n\n"},"schema":{"name":{"type":"string"},"broker-type":{"type":"string"},"configuration":{"type":"object"}}}'
+        for the broker.  The acceptable values here are\n     determined by the `broker-type`
+        selected.  In general this has\n     settings like which server to contact,
+        and other configuration\n     related to handing on the newly installed system
+        to the final\n     configuration management system.\n     \n     This attribute
+        can be abbreviated as `c` for convenience.\n   - It must be of type object.\n\n#
+        EXAMPLES\n\n  Creating a simple Puppet broker:\n  \n  {\n    \"name\": \"puppet\",\n    \"configuration\":
+        {\n       \"server\":      \"puppet.example.org\",\n       \"environment\":
+        \"production\"\n    },\n    \"broker-type\": \"puppet\"\n  }\n"},"schema":{"name":{"type":"string"},"broker-type":{"type":"string"},"configuration":{"type":"object"}}}'
     http_version:
-  recorded_at: Fri, 16 May 2014 22:18:28 GMT
+  recorded_at: Thu, 14 Aug 2014 20:49:46 GMT
+- request:
+    method: get
+    uri: http://localhost:8080/api/commands/create-broker
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Etag:
+      - '"server-version-v0.15.0-26-gfffaba4-dirty"'
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json;charset=utf-8
+      Content-Length:
+      - '2568'
+      Date:
+      - Thu, 14 Aug 2014 20:49:46 GMT
+    body:
+      encoding: US-ASCII
+      string: '{"name":"create-broker","help":{"full":"# SYNOPSIS\nCreate a new broker
+        configuration for hand-off of installed nodes\n\n# DESCRIPTION\nCreate a new
+        broker configuration.  Brokers are responsible for handing a node\noff to
+        a config management system, such as Puppet or Chef.  In cases where you\nhave
+        no configuration management system, you can use the `noop` broker.\n\n# Access
+        Control\n\nThis command''s access control pattern: `commands:create-broker:%{name}`\n\nWords
+        surrounded by `%{...}` are substitutions from the input data: typically\nthe
+        name of the object being modified, or some other critical detail, these\nallow
+        roles to be granted partial access to modify the system.\n\nFor more detail
+        on how the permission strings are structured and work, you can\nsee the [Shiro
+        Permissions documentation][shiro].  That pattern is expanded\nand then a permission
+        check applied to it, before the command is authorized.\n\nThese checks only
+        apply if security is enabled in the Razor configuration\nfile; on this server
+        security is currently disabled.\n\n[shiro]: http://shiro.apache.org/permissions.html\n\n#
+        Attributes\n\n * name\n   - The name of the broker, as it will be referenced
+        within Razor.\n     This is the name that you supply to, eg, `create-policy`
+        to specify\n     which broker the node will be handed off via after installation.\n   -
+        This attribute is required.\n   - It must be of type string.\n   - It must
+        be between 1 and 250 in length.\n\n * broker-type\n   - The broker type from
+        which this broker is created.  The available\n     broker types on your server
+        are:\n     - chef\n     - noop\n     - puppet-pe\n     - puppet\n   - This
+        attribute is required.\n   - It must be of type string.\n   - It must match
+        the name of an existing broker type.\n\n * configuration\n   - The configuration
+        for the broker.  The acceptable values here are\n     determined by the `broker-type`
+        selected.  In general this has\n     settings like which server to contact,
+        and other configuration\n     related to handing on the newly installed system
+        to the final\n     configuration management system.\n     \n     This attribute
+        can be abbreviated as `c` for convenience.\n   - It must be of type object.\n\n#
+        EXAMPLES\n\n  Creating a simple Puppet broker:\n  \n  {\n    \"name\": \"puppet\",\n    \"configuration\":
+        {\n       \"server\":      \"puppet.example.org\",\n       \"environment\":
+        \"production\"\n    },\n    \"broker-type\": \"puppet\"\n  }\n"},"schema":{"name":{"type":"string"},"broker-type":{"type":"string"},"configuration":{"type":"object"}}}'
+    http_version:
+  recorded_at: Thu, 14 Aug 2014 20:49:46 GMT
+- request:
+    method: get
+    uri: http://localhost:8080/api/commands/create-broker
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Etag:
+      - '"server-version-v0.15.0-26-gfffaba4-dirty"'
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json;charset=utf-8
+      Content-Length:
+      - '2568'
+      Date:
+      - Thu, 14 Aug 2014 20:49:46 GMT
+    body:
+      encoding: US-ASCII
+      string: '{"name":"create-broker","help":{"full":"# SYNOPSIS\nCreate a new broker
+        configuration for hand-off of installed nodes\n\n# DESCRIPTION\nCreate a new
+        broker configuration.  Brokers are responsible for handing a node\noff to
+        a config management system, such as Puppet or Chef.  In cases where you\nhave
+        no configuration management system, you can use the `noop` broker.\n\n# Access
+        Control\n\nThis command''s access control pattern: `commands:create-broker:%{name}`\n\nWords
+        surrounded by `%{...}` are substitutions from the input data: typically\nthe
+        name of the object being modified, or some other critical detail, these\nallow
+        roles to be granted partial access to modify the system.\n\nFor more detail
+        on how the permission strings are structured and work, you can\nsee the [Shiro
+        Permissions documentation][shiro].  That pattern is expanded\nand then a permission
+        check applied to it, before the command is authorized.\n\nThese checks only
+        apply if security is enabled in the Razor configuration\nfile; on this server
+        security is currently disabled.\n\n[shiro]: http://shiro.apache.org/permissions.html\n\n#
+        Attributes\n\n * name\n   - The name of the broker, as it will be referenced
+        within Razor.\n     This is the name that you supply to, eg, `create-policy`
+        to specify\n     which broker the node will be handed off via after installation.\n   -
+        This attribute is required.\n   - It must be of type string.\n   - It must
+        be between 1 and 250 in length.\n\n * broker-type\n   - The broker type from
+        which this broker is created.  The available\n     broker types on your server
+        are:\n     - chef\n     - noop\n     - puppet-pe\n     - puppet\n   - This
+        attribute is required.\n   - It must be of type string.\n   - It must match
+        the name of an existing broker type.\n\n * configuration\n   - The configuration
+        for the broker.  The acceptable values here are\n     determined by the `broker-type`
+        selected.  In general this has\n     settings like which server to contact,
+        and other configuration\n     related to handing on the newly installed system
+        to the final\n     configuration management system.\n     \n     This attribute
+        can be abbreviated as `c` for convenience.\n   - It must be of type object.\n\n#
+        EXAMPLES\n\n  Creating a simple Puppet broker:\n  \n  {\n    \"name\": \"puppet\",\n    \"configuration\":
+        {\n       \"server\":      \"puppet.example.org\",\n       \"environment\":
+        \"production\"\n    },\n    \"broker-type\": \"puppet\"\n  }\n"},"schema":{"name":{"type":"string"},"broker-type":{"type":"string"},"configuration":{"type":"object"}}}'
+    http_version:
+  recorded_at: Thu, 14 Aug 2014 20:49:46 GMT
 - request:
     method: post
     uri: http://localhost:8080/api/commands/create-broker
@@ -192,12 +324,12 @@ http_interactions:
       Content-Length:
       - '211'
       Date:
-      - Fri, 16 May 2014 22:18:28 GMT
+      - Thu, 14 Aug 2014 20:49:46 GMT
     body:
       encoding: US-ASCII
       string: '{"spec":"http://api.puppetlabs.com/razor/v1/collections/brokers/member","id":"http://localhost:8080/api/collections/brokers/broker1","name":"broker1","command":"http://localhost:8080/api/collections/commands/1"}'
     http_version:
-  recorded_at: Fri, 16 May 2014 22:18:28 GMT
+  recorded_at: Thu, 14 Aug 2014 20:49:47 GMT
 - request:
     method: get
     uri: http://localhost:8080/api/collections/brokers/broker1
@@ -225,10 +357,10 @@ http_interactions:
       Content-Length:
       - '359'
       Date:
-      - Fri, 16 May 2014 22:18:28 GMT
+      - Thu, 14 Aug 2014 20:49:46 GMT
     body:
       encoding: US-ASCII
       string: '{"spec":"http://api.puppetlabs.com/razor/v1/collections/brokers/member","id":"http://localhost:8080/api/collections/brokers/broker1","name":"broker1","configuration":{"server":"puppet.example.org","environment":"production"},"broker-type":"puppet","policies":{"id":"http://localhost:8080/api/collections/brokers/broker1/policies","count":0,"name":"policies"}}'
     http_version:
-  recorded_at: Fri, 16 May 2014 22:18:28 GMT
-recorded_with: VCR 2.5.0
+  recorded_at: Thu, 14 Aug 2014 20:49:47 GMT
+recorded_with: VCR 2.9.2

--- a/spec/fixtures/vcr/Razor_CLI_Navigate/with_multiple_arguments_with_same_name/combining_as_an_object/should_construct_a_json_object_with_unicode.yml
+++ b/spec/fixtures/vcr/Razor_CLI_Navigate/with_multiple_arguments_with_same_name/combining_as_an_object/should_construct_a_json_object_with_unicode.yml
@@ -4,7 +4,7 @@ http_interactions:
     method: get
     uri: http://localhost:8080/api
     body:
-      encoding: UTF-8
+      encoding: US-ASCII
       string: ''
     headers:
       Accept:
@@ -25,19 +25,19 @@ http_interactions:
       Content-Type:
       - application/json;charset=utf-8
       Content-Length:
-      - '4980'
+      - '4981'
       Date:
-      - Tue, 03 Jun 2014 23:18:44 GMT
+      - Thu, 14 Aug 2014 20:49:53 GMT
     body:
-      encoding: UTF-8
-      string: '{"commands":[{"name":"add-policy-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/add-policy-tag","id":"http://localhost:8080/api/commands/add-policy-tag"},{"name":"create-broker","rel":"http://api.puppetlabs.com/razor/v1/commands/create-broker","id":"http://localhost:8080/api/commands/create-broker"},{"name":"create-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/create-policy","id":"http://localhost:8080/api/commands/create-policy"},{"name":"create-repo","rel":"http://api.puppetlabs.com/razor/v1/commands/create-repo","id":"http://localhost:8080/api/commands/create-repo"},{"name":"create-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/create-tag","id":"http://localhost:8080/api/commands/create-tag"},{"name":"create-task","rel":"http://api.puppetlabs.com/razor/v1/commands/create-task","id":"http://localhost:8080/api/commands/create-task"},{"name":"delete-broker","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-broker","id":"http://localhost:8080/api/commands/delete-broker"},{"name":"delete-node","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-node","id":"http://localhost:8080/api/commands/delete-node"},{"name":"delete-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-policy","id":"http://localhost:8080/api/commands/delete-policy"},{"name":"delete-repo","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-repo","id":"http://localhost:8080/api/commands/delete-repo"},{"name":"delete-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-tag","id":"http://localhost:8080/api/commands/delete-tag"},{"name":"disable-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/disable-policy","id":"http://localhost:8080/api/commands/disable-policy"},{"name":"enable-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/enable-policy","id":"http://localhost:8080/api/commands/enable-policy"},{"name":"modify-node-metadata","rel":"http://api.puppetlabs.com/razor/v1/commands/modify-node-metadata","id":"http://localhost:8080/api/commands/modify-node-metadata"},{"name":"modify-policy-max-count","rel":"http://api.puppetlabs.com/razor/v1/commands/modify-policy-max-count","id":"http://localhost:8080/api/commands/modify-policy-max-count"},{"name":"move-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/move-policy","id":"http://localhost:8080/api/commands/move-policy"},{"name":"reboot-node","rel":"http://api.puppetlabs.com/razor/v1/commands/reboot-node","id":"http://localhost:8080/api/commands/reboot-node"},{"name":"register-node","rel":"http://api.puppetlabs.com/razor/v1/commands/register-node","id":"http://localhost:8080/api/commands/register-node"},{"name":"reinstall-node","rel":"http://api.puppetlabs.com/razor/v1/commands/reinstall-node","id":"http://localhost:8080/api/commands/reinstall-node"},{"name":"remove-node-metadata","rel":"http://api.puppetlabs.com/razor/v1/commands/remove-node-metadata","id":"http://localhost:8080/api/commands/remove-node-metadata"},{"name":"remove-policy-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/remove-policy-tag","id":"http://localhost:8080/api/commands/remove-policy-tag"},{"name":"set-node-desired-power-state","rel":"http://api.puppetlabs.com/razor/v1/commands/set-node-desired-power-state","id":"http://localhost:8080/api/commands/set-node-desired-power-state"},{"name":"set-node-hw-info","rel":"http://api.puppetlabs.com/razor/v1/commands/set-node-hw-info","id":"http://localhost:8080/api/commands/set-node-hw-info"},{"name":"set-node-ipmi-credentials","rel":"http://api.puppetlabs.com/razor/v1/commands/set-node-ipmi-credentials","id":"http://localhost:8080/api/commands/set-node-ipmi-credentials"},{"name":"update-node-metadata","rel":"http://api.puppetlabs.com/razor/v1/commands/update-node-metadata","id":"http://localhost:8080/api/commands/update-node-metadata"},{"name":"update-tag-rule","rel":"http://api.puppetlabs.com/razor/v1/commands/update-tag-rule","id":"http://localhost:8080/api/commands/update-tag-rule"}],"collections":[{"name":"brokers","rel":"http://api.puppetlabs.com/razor/v1/collections/brokers","id":"http://localhost:8080/api/collections/brokers"},{"name":"repos","rel":"http://api.puppetlabs.com/razor/v1/collections/repos","id":"http://localhost:8080/api/collections/repos"},{"name":"tags","rel":"http://api.puppetlabs.com/razor/v1/collections/tags","id":"http://localhost:8080/api/collections/tags"},{"name":"policies","rel":"http://api.puppetlabs.com/razor/v1/collections/policies","id":"http://localhost:8080/api/collections/policies"},{"name":"nodes","rel":"http://api.puppetlabs.com/razor/v1/collections/nodes","id":"http://localhost:8080/api/collections/nodes"},{"name":"tasks","rel":"http://api.puppetlabs.com/razor/v1/collections/tasks","id":"http://localhost:8080/api/collections/tasks"},{"name":"commands","rel":"http://api.puppetlabs.com/razor/v1/collections/commands","id":"http://localhost:8080/api/collections/commands"}],"version":{"server":"v0.15.0-3-gb0cbb3f-dirty"}}'
+      encoding: US-ASCII
+      string: '{"commands":[{"name":"add-policy-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/add-policy-tag","id":"http://localhost:8080/api/commands/add-policy-tag"},{"name":"create-broker","rel":"http://api.puppetlabs.com/razor/v1/commands/create-broker","id":"http://localhost:8080/api/commands/create-broker"},{"name":"create-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/create-policy","id":"http://localhost:8080/api/commands/create-policy"},{"name":"create-repo","rel":"http://api.puppetlabs.com/razor/v1/commands/create-repo","id":"http://localhost:8080/api/commands/create-repo"},{"name":"create-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/create-tag","id":"http://localhost:8080/api/commands/create-tag"},{"name":"create-task","rel":"http://api.puppetlabs.com/razor/v1/commands/create-task","id":"http://localhost:8080/api/commands/create-task"},{"name":"delete-broker","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-broker","id":"http://localhost:8080/api/commands/delete-broker"},{"name":"delete-node","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-node","id":"http://localhost:8080/api/commands/delete-node"},{"name":"delete-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-policy","id":"http://localhost:8080/api/commands/delete-policy"},{"name":"delete-repo","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-repo","id":"http://localhost:8080/api/commands/delete-repo"},{"name":"delete-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-tag","id":"http://localhost:8080/api/commands/delete-tag"},{"name":"disable-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/disable-policy","id":"http://localhost:8080/api/commands/disable-policy"},{"name":"enable-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/enable-policy","id":"http://localhost:8080/api/commands/enable-policy"},{"name":"modify-node-metadata","rel":"http://api.puppetlabs.com/razor/v1/commands/modify-node-metadata","id":"http://localhost:8080/api/commands/modify-node-metadata"},{"name":"modify-policy-max-count","rel":"http://api.puppetlabs.com/razor/v1/commands/modify-policy-max-count","id":"http://localhost:8080/api/commands/modify-policy-max-count"},{"name":"move-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/move-policy","id":"http://localhost:8080/api/commands/move-policy"},{"name":"reboot-node","rel":"http://api.puppetlabs.com/razor/v1/commands/reboot-node","id":"http://localhost:8080/api/commands/reboot-node"},{"name":"register-node","rel":"http://api.puppetlabs.com/razor/v1/commands/register-node","id":"http://localhost:8080/api/commands/register-node"},{"name":"reinstall-node","rel":"http://api.puppetlabs.com/razor/v1/commands/reinstall-node","id":"http://localhost:8080/api/commands/reinstall-node"},{"name":"remove-node-metadata","rel":"http://api.puppetlabs.com/razor/v1/commands/remove-node-metadata","id":"http://localhost:8080/api/commands/remove-node-metadata"},{"name":"remove-policy-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/remove-policy-tag","id":"http://localhost:8080/api/commands/remove-policy-tag"},{"name":"set-node-desired-power-state","rel":"http://api.puppetlabs.com/razor/v1/commands/set-node-desired-power-state","id":"http://localhost:8080/api/commands/set-node-desired-power-state"},{"name":"set-node-hw-info","rel":"http://api.puppetlabs.com/razor/v1/commands/set-node-hw-info","id":"http://localhost:8080/api/commands/set-node-hw-info"},{"name":"set-node-ipmi-credentials","rel":"http://api.puppetlabs.com/razor/v1/commands/set-node-ipmi-credentials","id":"http://localhost:8080/api/commands/set-node-ipmi-credentials"},{"name":"update-node-metadata","rel":"http://api.puppetlabs.com/razor/v1/commands/update-node-metadata","id":"http://localhost:8080/api/commands/update-node-metadata"},{"name":"update-tag-rule","rel":"http://api.puppetlabs.com/razor/v1/commands/update-tag-rule","id":"http://localhost:8080/api/commands/update-tag-rule"}],"collections":[{"name":"brokers","rel":"http://api.puppetlabs.com/razor/v1/collections/brokers","id":"http://localhost:8080/api/collections/brokers"},{"name":"repos","rel":"http://api.puppetlabs.com/razor/v1/collections/repos","id":"http://localhost:8080/api/collections/repos"},{"name":"tags","rel":"http://api.puppetlabs.com/razor/v1/collections/tags","id":"http://localhost:8080/api/collections/tags"},{"name":"policies","rel":"http://api.puppetlabs.com/razor/v1/collections/policies","id":"http://localhost:8080/api/collections/policies"},{"name":"nodes","rel":"http://api.puppetlabs.com/razor/v1/collections/nodes","id":"http://localhost:8080/api/collections/nodes"},{"name":"tasks","rel":"http://api.puppetlabs.com/razor/v1/collections/tasks","id":"http://localhost:8080/api/collections/tasks"},{"name":"commands","rel":"http://api.puppetlabs.com/razor/v1/collections/commands","id":"http://localhost:8080/api/collections/commands"}],"version":{"server":"v0.15.0-26-gfffaba4-dirty"}}'
     http_version:
-  recorded_at: Tue, 03 Jun 2014 23:18:44 GMT
+  recorded_at: Thu, 14 Aug 2014 20:49:53 GMT
 - request:
     method: get
     uri: http://localhost:8080/api/commands/register-node
     body:
-      encoding: UTF-8
+      encoding: US-ASCII
       string: ''
     headers:
       Accept:
@@ -54,7 +54,7 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       Etag:
-      - '"server-version-v0.15.0-3-gb0cbb3f-dirty"'
+      - '"server-version-v0.15.0-26-gfffaba4-dirty"'
       X-Content-Type-Options:
       - nosniff
       Content-Type:
@@ -62,9 +62,9 @@ http_interactions:
       Content-Length:
       - '2936'
       Date:
-      - Tue, 03 Jun 2014 23:18:44 GMT
+      - Thu, 14 Aug 2014 20:49:53 GMT
     body:
-      encoding: UTF-8
+      encoding: US-ASCII
       string: '{"name":"register-node","help":{"full":"# SYNOPSIS\nRegister a node
         with Razor before it is discovered\n\n# DESCRIPTION\nIn order to make brownfield
         deployments of Razor easier we allow users to\nregister nodes explicitly.  This
@@ -101,12 +101,12 @@ http_interactions:
         \"xxxxxxxxxxx\",\n          \"asset\":  \"Asset-1234567890\",\n          \"uuid\":   \"Not
         Settable\"\n        },\n        \"installed\": true\n      }\n"},"schema":{"installed":{"type":"boolean"},"hw-info":{"type":"object"}}}'
     http_version:
-  recorded_at: Tue, 03 Jun 2014 23:18:45 GMT
+  recorded_at: Thu, 14 Aug 2014 20:49:53 GMT
 - request:
     method: get
     uri: http://localhost:8080/api/commands/register-node
     body:
-      encoding: UTF-8
+      encoding: US-ASCII
       string: ''
     headers:
       Accept:
@@ -123,7 +123,7 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       Etag:
-      - '"server-version-v0.15.0-3-gb0cbb3f-dirty"'
+      - '"server-version-v0.15.0-26-gfffaba4-dirty"'
       X-Content-Type-Options:
       - nosniff
       Content-Type:
@@ -131,9 +131,9 @@ http_interactions:
       Content-Length:
       - '2936'
       Date:
-      - Tue, 03 Jun 2014 23:18:44 GMT
+      - Thu, 14 Aug 2014 20:49:53 GMT
     body:
-      encoding: UTF-8
+      encoding: US-ASCII
       string: '{"name":"register-node","help":{"full":"# SYNOPSIS\nRegister a node
         with Razor before it is discovered\n\n# DESCRIPTION\nIn order to make brownfield
         deployments of Razor easier we allow users to\nregister nodes explicitly.  This
@@ -170,7 +170,7 @@ http_interactions:
         \"xxxxxxxxxxx\",\n          \"asset\":  \"Asset-1234567890\",\n          \"uuid\":   \"Not
         Settable\"\n        },\n        \"installed\": true\n      }\n"},"schema":{"installed":{"type":"boolean"},"hw-info":{"type":"object"}}}'
     http_version:
-  recorded_at: Tue, 03 Jun 2014 23:18:45 GMT
+  recorded_at: Thu, 14 Aug 2014 20:49:53 GMT
 - request:
     method: post
     uri: http://localhost:8080/api/commands/register-node
@@ -202,17 +202,17 @@ http_interactions:
       Content-Length:
       - '203'
       Date:
-      - Tue, 03 Jun 2014 23:18:44 GMT
+      - Thu, 14 Aug 2014 20:49:53 GMT
     body:
-      encoding: UTF-8
+      encoding: US-ASCII
       string: '{"spec":"http://api.puppetlabs.com/razor/v1/collections/nodes/member","id":"http://localhost:8080/api/collections/nodes/node1","name":"node1","command":"http://localhost:8080/api/collections/commands/1"}'
     http_version:
-  recorded_at: Tue, 03 Jun 2014 23:18:45 GMT
+  recorded_at: Thu, 14 Aug 2014 20:49:53 GMT
 - request:
     method: get
     uri: http://localhost:8080/api/collections/nodes/node1
     body:
-      encoding: UTF-8
+      encoding: US-ASCII
       string: ''
     headers:
       Accept:
@@ -233,19 +233,19 @@ http_interactions:
       Content-Type:
       - application/json;charset=utf-8
       Content-Length:
-      - '335'
+      - '376'
       Date:
-      - Tue, 03 Jun 2014 23:18:44 GMT
+      - Thu, 14 Aug 2014 20:49:53 GMT
     body:
-      encoding: UTF-8
-      string: '{"spec":"http://api.puppetlabs.com/razor/v1/collections/nodes/member","id":"http://localhost:8080/api/collections/nodes/node1","name":"node1","hw_info":{"mac":["abcdef"]},"log":{"id":"http://localhost:8080/api/collections/nodes/node1/log","name":"log"},"tags":[],"state":{"installed":"true","installed_at":"2014-06-03T18:18:45-05:00"}}'
+      encoding: US-ASCII
+      string: '{"spec":"http://api.puppetlabs.com/razor/v1/collections/nodes/member","id":"http://localhost:8080/api/collections/nodes/node1","name":"node1","hw_info":{"mac":["abcdef"]},"log":{"id":"http://localhost:8080/api/collections/nodes/node1/log","name":"log"},"tags":[],"state":{"installed":"true","installed_at":"2014-08-14T15:49:53-05:00"},"ipmi":{"hostname":null,"username":null}}'
     http_version:
-  recorded_at: Tue, 03 Jun 2014 23:18:45 GMT
+  recorded_at: Thu, 14 Aug 2014 20:49:53 GMT
 - request:
     method: get
     uri: http://localhost:8080/api
     body:
-      encoding: UTF-8
+      encoding: US-ASCII
       string: ''
     headers:
       Accept:
@@ -266,19 +266,19 @@ http_interactions:
       Content-Type:
       - application/json;charset=utf-8
       Content-Length:
-      - '4980'
+      - '4981'
       Date:
-      - Tue, 03 Jun 2014 23:18:44 GMT
+      - Thu, 14 Aug 2014 20:49:53 GMT
     body:
-      encoding: UTF-8
-      string: '{"commands":[{"name":"add-policy-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/add-policy-tag","id":"http://localhost:8080/api/commands/add-policy-tag"},{"name":"create-broker","rel":"http://api.puppetlabs.com/razor/v1/commands/create-broker","id":"http://localhost:8080/api/commands/create-broker"},{"name":"create-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/create-policy","id":"http://localhost:8080/api/commands/create-policy"},{"name":"create-repo","rel":"http://api.puppetlabs.com/razor/v1/commands/create-repo","id":"http://localhost:8080/api/commands/create-repo"},{"name":"create-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/create-tag","id":"http://localhost:8080/api/commands/create-tag"},{"name":"create-task","rel":"http://api.puppetlabs.com/razor/v1/commands/create-task","id":"http://localhost:8080/api/commands/create-task"},{"name":"delete-broker","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-broker","id":"http://localhost:8080/api/commands/delete-broker"},{"name":"delete-node","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-node","id":"http://localhost:8080/api/commands/delete-node"},{"name":"delete-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-policy","id":"http://localhost:8080/api/commands/delete-policy"},{"name":"delete-repo","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-repo","id":"http://localhost:8080/api/commands/delete-repo"},{"name":"delete-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-tag","id":"http://localhost:8080/api/commands/delete-tag"},{"name":"disable-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/disable-policy","id":"http://localhost:8080/api/commands/disable-policy"},{"name":"enable-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/enable-policy","id":"http://localhost:8080/api/commands/enable-policy"},{"name":"modify-node-metadata","rel":"http://api.puppetlabs.com/razor/v1/commands/modify-node-metadata","id":"http://localhost:8080/api/commands/modify-node-metadata"},{"name":"modify-policy-max-count","rel":"http://api.puppetlabs.com/razor/v1/commands/modify-policy-max-count","id":"http://localhost:8080/api/commands/modify-policy-max-count"},{"name":"move-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/move-policy","id":"http://localhost:8080/api/commands/move-policy"},{"name":"reboot-node","rel":"http://api.puppetlabs.com/razor/v1/commands/reboot-node","id":"http://localhost:8080/api/commands/reboot-node"},{"name":"register-node","rel":"http://api.puppetlabs.com/razor/v1/commands/register-node","id":"http://localhost:8080/api/commands/register-node"},{"name":"reinstall-node","rel":"http://api.puppetlabs.com/razor/v1/commands/reinstall-node","id":"http://localhost:8080/api/commands/reinstall-node"},{"name":"remove-node-metadata","rel":"http://api.puppetlabs.com/razor/v1/commands/remove-node-metadata","id":"http://localhost:8080/api/commands/remove-node-metadata"},{"name":"remove-policy-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/remove-policy-tag","id":"http://localhost:8080/api/commands/remove-policy-tag"},{"name":"set-node-desired-power-state","rel":"http://api.puppetlabs.com/razor/v1/commands/set-node-desired-power-state","id":"http://localhost:8080/api/commands/set-node-desired-power-state"},{"name":"set-node-hw-info","rel":"http://api.puppetlabs.com/razor/v1/commands/set-node-hw-info","id":"http://localhost:8080/api/commands/set-node-hw-info"},{"name":"set-node-ipmi-credentials","rel":"http://api.puppetlabs.com/razor/v1/commands/set-node-ipmi-credentials","id":"http://localhost:8080/api/commands/set-node-ipmi-credentials"},{"name":"update-node-metadata","rel":"http://api.puppetlabs.com/razor/v1/commands/update-node-metadata","id":"http://localhost:8080/api/commands/update-node-metadata"},{"name":"update-tag-rule","rel":"http://api.puppetlabs.com/razor/v1/commands/update-tag-rule","id":"http://localhost:8080/api/commands/update-tag-rule"}],"collections":[{"name":"brokers","rel":"http://api.puppetlabs.com/razor/v1/collections/brokers","id":"http://localhost:8080/api/collections/brokers"},{"name":"repos","rel":"http://api.puppetlabs.com/razor/v1/collections/repos","id":"http://localhost:8080/api/collections/repos"},{"name":"tags","rel":"http://api.puppetlabs.com/razor/v1/collections/tags","id":"http://localhost:8080/api/collections/tags"},{"name":"policies","rel":"http://api.puppetlabs.com/razor/v1/collections/policies","id":"http://localhost:8080/api/collections/policies"},{"name":"nodes","rel":"http://api.puppetlabs.com/razor/v1/collections/nodes","id":"http://localhost:8080/api/collections/nodes"},{"name":"tasks","rel":"http://api.puppetlabs.com/razor/v1/collections/tasks","id":"http://localhost:8080/api/collections/tasks"},{"name":"commands","rel":"http://api.puppetlabs.com/razor/v1/collections/commands","id":"http://localhost:8080/api/collections/commands"}],"version":{"server":"v0.15.0-3-gb0cbb3f-dirty"}}'
+      encoding: US-ASCII
+      string: '{"commands":[{"name":"add-policy-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/add-policy-tag","id":"http://localhost:8080/api/commands/add-policy-tag"},{"name":"create-broker","rel":"http://api.puppetlabs.com/razor/v1/commands/create-broker","id":"http://localhost:8080/api/commands/create-broker"},{"name":"create-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/create-policy","id":"http://localhost:8080/api/commands/create-policy"},{"name":"create-repo","rel":"http://api.puppetlabs.com/razor/v1/commands/create-repo","id":"http://localhost:8080/api/commands/create-repo"},{"name":"create-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/create-tag","id":"http://localhost:8080/api/commands/create-tag"},{"name":"create-task","rel":"http://api.puppetlabs.com/razor/v1/commands/create-task","id":"http://localhost:8080/api/commands/create-task"},{"name":"delete-broker","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-broker","id":"http://localhost:8080/api/commands/delete-broker"},{"name":"delete-node","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-node","id":"http://localhost:8080/api/commands/delete-node"},{"name":"delete-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-policy","id":"http://localhost:8080/api/commands/delete-policy"},{"name":"delete-repo","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-repo","id":"http://localhost:8080/api/commands/delete-repo"},{"name":"delete-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-tag","id":"http://localhost:8080/api/commands/delete-tag"},{"name":"disable-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/disable-policy","id":"http://localhost:8080/api/commands/disable-policy"},{"name":"enable-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/enable-policy","id":"http://localhost:8080/api/commands/enable-policy"},{"name":"modify-node-metadata","rel":"http://api.puppetlabs.com/razor/v1/commands/modify-node-metadata","id":"http://localhost:8080/api/commands/modify-node-metadata"},{"name":"modify-policy-max-count","rel":"http://api.puppetlabs.com/razor/v1/commands/modify-policy-max-count","id":"http://localhost:8080/api/commands/modify-policy-max-count"},{"name":"move-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/move-policy","id":"http://localhost:8080/api/commands/move-policy"},{"name":"reboot-node","rel":"http://api.puppetlabs.com/razor/v1/commands/reboot-node","id":"http://localhost:8080/api/commands/reboot-node"},{"name":"register-node","rel":"http://api.puppetlabs.com/razor/v1/commands/register-node","id":"http://localhost:8080/api/commands/register-node"},{"name":"reinstall-node","rel":"http://api.puppetlabs.com/razor/v1/commands/reinstall-node","id":"http://localhost:8080/api/commands/reinstall-node"},{"name":"remove-node-metadata","rel":"http://api.puppetlabs.com/razor/v1/commands/remove-node-metadata","id":"http://localhost:8080/api/commands/remove-node-metadata"},{"name":"remove-policy-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/remove-policy-tag","id":"http://localhost:8080/api/commands/remove-policy-tag"},{"name":"set-node-desired-power-state","rel":"http://api.puppetlabs.com/razor/v1/commands/set-node-desired-power-state","id":"http://localhost:8080/api/commands/set-node-desired-power-state"},{"name":"set-node-hw-info","rel":"http://api.puppetlabs.com/razor/v1/commands/set-node-hw-info","id":"http://localhost:8080/api/commands/set-node-hw-info"},{"name":"set-node-ipmi-credentials","rel":"http://api.puppetlabs.com/razor/v1/commands/set-node-ipmi-credentials","id":"http://localhost:8080/api/commands/set-node-ipmi-credentials"},{"name":"update-node-metadata","rel":"http://api.puppetlabs.com/razor/v1/commands/update-node-metadata","id":"http://localhost:8080/api/commands/update-node-metadata"},{"name":"update-tag-rule","rel":"http://api.puppetlabs.com/razor/v1/commands/update-tag-rule","id":"http://localhost:8080/api/commands/update-tag-rule"}],"collections":[{"name":"brokers","rel":"http://api.puppetlabs.com/razor/v1/collections/brokers","id":"http://localhost:8080/api/collections/brokers"},{"name":"repos","rel":"http://api.puppetlabs.com/razor/v1/collections/repos","id":"http://localhost:8080/api/collections/repos"},{"name":"tags","rel":"http://api.puppetlabs.com/razor/v1/collections/tags","id":"http://localhost:8080/api/collections/tags"},{"name":"policies","rel":"http://api.puppetlabs.com/razor/v1/collections/policies","id":"http://localhost:8080/api/collections/policies"},{"name":"nodes","rel":"http://api.puppetlabs.com/razor/v1/collections/nodes","id":"http://localhost:8080/api/collections/nodes"},{"name":"tasks","rel":"http://api.puppetlabs.com/razor/v1/collections/tasks","id":"http://localhost:8080/api/collections/tasks"},{"name":"commands","rel":"http://api.puppetlabs.com/razor/v1/collections/commands","id":"http://localhost:8080/api/collections/commands"}],"version":{"server":"v0.15.0-26-gfffaba4-dirty"}}'
     http_version:
-  recorded_at: Tue, 03 Jun 2014 23:18:45 GMT
+  recorded_at: Thu, 14 Aug 2014 20:49:53 GMT
 - request:
     method: get
     uri: http://localhost:8080/api/commands/modify-node-metadata
     body:
-      encoding: UTF-8
+      encoding: US-ASCII
       string: ''
     headers:
       Accept:
@@ -295,7 +295,7 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       Etag:
-      - '"server-version-v0.15.0-3-gb0cbb3f-dirty"'
+      - '"server-version-v0.15.0-26-gfffaba4-dirty"'
       X-Content-Type-Options:
       - nosniff
       Content-Type:
@@ -303,9 +303,9 @@ http_interactions:
       Content-Length:
       - '2610'
       Date:
-      - Tue, 03 Jun 2014 23:18:44 GMT
+      - Thu, 14 Aug 2014 20:49:53 GMT
     body:
-      encoding: UTF-8
+      encoding: US-ASCII
       string: '{"name":"modify-node-metadata","help":{"full":"# SYNOPSIS\nPerform
         various editing operations on node metadata\n\n# DESCRIPTION\nNode metadata
         can be added, changed, or removed with this command; it contains\na limited
@@ -338,7 +338,72 @@ http_interactions:
         true\n      }\n  \n  Removing all node metadata:\n  \n      {\"node\": \"node1\",
         \"clear\": true}\n"},"schema":{"node":{"type":"string"},"update":{"type":"object"},"remove":{"type":"array"},"clear":{"type":"boolean"},"no-replace":{"type":"boolean"}}}'
     http_version:
-  recorded_at: Tue, 03 Jun 2014 23:18:45 GMT
+  recorded_at: Thu, 14 Aug 2014 20:49:53 GMT
+- request:
+    method: get
+    uri: http://localhost:8080/api/commands/modify-node-metadata
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Etag:
+      - '"server-version-v0.15.0-26-gfffaba4-dirty"'
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json;charset=utf-8
+      Content-Length:
+      - '2610'
+      Date:
+      - Thu, 14 Aug 2014 20:49:53 GMT
+    body:
+      encoding: US-ASCII
+      string: '{"name":"modify-node-metadata","help":{"full":"# SYNOPSIS\nPerform
+        various editing operations on node metadata\n\n# DESCRIPTION\nNode metadata
+        can be added, changed, or removed with this command; it contains\na limited
+        editing language to make changes to the existing metadata in an\natomic fashion.\n\nIt
+        can also clear all metadata from a node, although that operation is\nexclusive
+        to all other editing operations, and cannot be performed atomically\nwith
+        them.\n\n# Access Control\n\nThis command''s access control pattern: `commands:modify-node-metadata:%{node}`\n\nWords
+        surrounded by `%{...}` are substitutions from the input data: typically\nthe
+        name of the object being modified, or some other critical detail, these\nallow
+        roles to be granted partial access to modify the system.\n\nFor more detail
+        on how the permission strings are structured and work, you can\nsee the [Shiro
+        Permissions documentation][shiro].  That pattern is expanded\nand then a permission
+        check applied to it, before the command is authorized.\n\nThese checks only
+        apply if security is enabled in the Razor configuration\nfile; on this server
+        security is currently disabled.\n\n[shiro]: http://shiro.apache.org/permissions.html\n\n#
+        Attributes\n\n * node\n   - The name of the node for which to modify metadata.\n   -
+        This attribute is required.\n   - It must be of type string.\n   - It must
+        match the name of an existing node.\n\n * update\n   - The metadata to update\n   -
+        It must be of type object.\n\n * remove\n   - The metadata to remove\n   -
+        It must be of type array.\n\n * clear\n   - Remove all metadata from the node.  Cannot
+        be used together with\n     either ''update'' or ''remove''.\n   - It must
+        be of type boolean.\n   - If present, update, remove must not be present.\n\n
+        * no-replace\n   - If true, the `update` operation will cause this command
+        to fail if the\n     metadata key is already present on the node.  No effect
+        on `remove` or\n     clear.\n   - It must be of type boolean.\n\n# EXAMPLES\n\n  Editing
+        node metadata, by adding and removing some keys, but refusing to\n  modify
+        an existing value already present on a node:\n  \n      {\n          \"node\":
+        \"node1\",\n          \"update\": {\n              \"key1\": \"value1\",\n              \"key2\":
+        \"value2\"\n          }\n          \"remove\": [\"key3\", \"key4\"],\n          \"no-replace\":
+        true\n      }\n  \n  Removing all node metadata:\n  \n      {\"node\": \"node1\",
+        \"clear\": true}\n"},"schema":{"node":{"type":"string"},"update":{"type":"object"},"remove":{"type":"array"},"clear":{"type":"boolean"},"no-replace":{"type":"boolean"}}}'
+    http_version:
+  recorded_at: Thu, 14 Aug 2014 20:49:53 GMT
 - request:
     method: post
     uri: http://localhost:8080/api/commands/modify-node-metadata
@@ -370,17 +435,17 @@ http_interactions:
       Content-Length:
       - '203'
       Date:
-      - Tue, 03 Jun 2014 23:18:44 GMT
+      - Thu, 14 Aug 2014 20:49:53 GMT
     body:
-      encoding: UTF-8
+      encoding: US-ASCII
       string: '{"spec":"http://api.puppetlabs.com/razor/v1/collections/nodes/member","id":"http://localhost:8080/api/collections/nodes/node1","name":"node1","command":"http://localhost:8080/api/collections/commands/2"}'
     http_version:
-  recorded_at: Tue, 03 Jun 2014 23:18:45 GMT
+  recorded_at: Thu, 14 Aug 2014 20:49:53 GMT
 - request:
     method: get
     uri: http://localhost:8080/api/collections/nodes/node1
     body:
-      encoding: UTF-8
+      encoding: US-ASCII
       string: ''
     headers:
       Accept:
@@ -401,12 +466,22 @@ http_interactions:
       Content-Type:
       - application/json;charset=utf-8
       Content-Length:
-      - '368'
+      - '413'
       Date:
-      - Tue, 03 Jun 2014 23:18:44 GMT
+      - Thu, 14 Aug 2014 20:49:53 GMT
     body:
-      encoding: UTF-8
-      string: '{"spec":"http://api.puppetlabs.com/razor/v1/collections/nodes/member","id":"http://localhost:8080/api/collections/nodes/node1","name":"node1","hw_info":{"mac":["abcdef"]},"log":{"id":"http://localhost:8080/api/collections/nodes/node1/log","name":"log"},"tags":[],"metadata":{"keyᓱ123":"valueᓱ1"},"state":{"installed":"true","installed_at":"2014-06-03T18:18:45-05:00"}}'
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJzcGVjIjoiaHR0cDovL2FwaS5wdXBwZXRsYWJzLmNvbS9yYXpvci92MS9j
+        b2xsZWN0aW9ucy9ub2Rlcy9tZW1iZXIiLCJpZCI6Imh0dHA6Ly9sb2NhbGhv
+        c3Q6ODA4MC9hcGkvY29sbGVjdGlvbnMvbm9kZXMvbm9kZTEiLCJuYW1lIjoi
+        bm9kZTEiLCJod19pbmZvIjp7Im1hYyI6WyJhYmNkZWYiXX0sImxvZyI6eyJp
+        ZCI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODA4MC9hcGkvY29sbGVjdGlvbnMvbm9k
+        ZXMvbm9kZTEvbG9nIiwibmFtZSI6ImxvZyJ9LCJ0YWdzIjpbXSwibWV0YWRh
+        dGEiOnsia2V54ZOxMTIzIjoidmFsdWXhk7ExIn0sInN0YXRlIjp7Imluc3Rh
+        bGxlZCI6InRydWUiLCJpbnN0YWxsZWRfYXQiOiIyMDE0LTA4LTE0VDE1OjQ5
+        OjUzLTA1OjAwIn0sImlwbWkiOnsiaG9zdG5hbWUiOm51bGwsInVzZXJuYW1l
+        IjpudWxsfX0=
     http_version:
-  recorded_at: Tue, 03 Jun 2014 23:18:45 GMT
-recorded_with: VCR 2.5.0
+  recorded_at: Thu, 14 Aug 2014 20:49:53 GMT
+recorded_with: VCR 2.9.2

--- a/spec/fixtures/vcr/Razor_CLI_Navigate/with_multiple_arguments_with_same_name/combining_as_an_object/should_fail_with_mixed_types_array_then_hash_.yml
+++ b/spec/fixtures/vcr/Razor_CLI_Navigate/with_multiple_arguments_with_same_name/combining_as_an_object/should_fail_with_mixed_types_array_then_hash_.yml
@@ -25,14 +25,14 @@ http_interactions:
       Content-Type:
       - application/json;charset=utf-8
       Content-Length:
-      - '4982'
+      - '4981'
       Date:
-      - Fri, 16 May 2014 22:18:33 GMT
+      - Thu, 14 Aug 2014 20:50:00 GMT
     body:
       encoding: US-ASCII
-      string: '{"commands":[{"name":"add-policy-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/add-policy-tag","id":"http://localhost:8080/api/commands/add-policy-tag"},{"name":"create-broker","rel":"http://api.puppetlabs.com/razor/v1/commands/create-broker","id":"http://localhost:8080/api/commands/create-broker"},{"name":"create-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/create-policy","id":"http://localhost:8080/api/commands/create-policy"},{"name":"create-repo","rel":"http://api.puppetlabs.com/razor/v1/commands/create-repo","id":"http://localhost:8080/api/commands/create-repo"},{"name":"create-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/create-tag","id":"http://localhost:8080/api/commands/create-tag"},{"name":"create-task","rel":"http://api.puppetlabs.com/razor/v1/commands/create-task","id":"http://localhost:8080/api/commands/create-task"},{"name":"delete-broker","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-broker","id":"http://localhost:8080/api/commands/delete-broker"},{"name":"delete-node","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-node","id":"http://localhost:8080/api/commands/delete-node"},{"name":"delete-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-policy","id":"http://localhost:8080/api/commands/delete-policy"},{"name":"delete-repo","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-repo","id":"http://localhost:8080/api/commands/delete-repo"},{"name":"delete-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-tag","id":"http://localhost:8080/api/commands/delete-tag"},{"name":"disable-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/disable-policy","id":"http://localhost:8080/api/commands/disable-policy"},{"name":"enable-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/enable-policy","id":"http://localhost:8080/api/commands/enable-policy"},{"name":"modify-node-metadata","rel":"http://api.puppetlabs.com/razor/v1/commands/modify-node-metadata","id":"http://localhost:8080/api/commands/modify-node-metadata"},{"name":"modify-policy-max-count","rel":"http://api.puppetlabs.com/razor/v1/commands/modify-policy-max-count","id":"http://localhost:8080/api/commands/modify-policy-max-count"},{"name":"move-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/move-policy","id":"http://localhost:8080/api/commands/move-policy"},{"name":"reboot-node","rel":"http://api.puppetlabs.com/razor/v1/commands/reboot-node","id":"http://localhost:8080/api/commands/reboot-node"},{"name":"register-node","rel":"http://api.puppetlabs.com/razor/v1/commands/register-node","id":"http://localhost:8080/api/commands/register-node"},{"name":"reinstall-node","rel":"http://api.puppetlabs.com/razor/v1/commands/reinstall-node","id":"http://localhost:8080/api/commands/reinstall-node"},{"name":"remove-node-metadata","rel":"http://api.puppetlabs.com/razor/v1/commands/remove-node-metadata","id":"http://localhost:8080/api/commands/remove-node-metadata"},{"name":"remove-policy-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/remove-policy-tag","id":"http://localhost:8080/api/commands/remove-policy-tag"},{"name":"set-node-desired-power-state","rel":"http://api.puppetlabs.com/razor/v1/commands/set-node-desired-power-state","id":"http://localhost:8080/api/commands/set-node-desired-power-state"},{"name":"set-node-hw-info","rel":"http://api.puppetlabs.com/razor/v1/commands/set-node-hw-info","id":"http://localhost:8080/api/commands/set-node-hw-info"},{"name":"set-node-ipmi-credentials","rel":"http://api.puppetlabs.com/razor/v1/commands/set-node-ipmi-credentials","id":"http://localhost:8080/api/commands/set-node-ipmi-credentials"},{"name":"update-node-metadata","rel":"http://api.puppetlabs.com/razor/v1/commands/update-node-metadata","id":"http://localhost:8080/api/commands/update-node-metadata"},{"name":"update-tag-rule","rel":"http://api.puppetlabs.com/razor/v1/commands/update-tag-rule","id":"http://localhost:8080/api/commands/update-tag-rule"}],"collections":[{"name":"brokers","rel":"http://api.puppetlabs.com/razor/v1/collections/brokers","id":"http://localhost:8080/api/collections/brokers"},{"name":"repos","rel":"http://api.puppetlabs.com/razor/v1/collections/repos","id":"http://localhost:8080/api/collections/repos"},{"name":"tags","rel":"http://api.puppetlabs.com/razor/v1/collections/tags","id":"http://localhost:8080/api/collections/tags"},{"name":"policies","rel":"http://api.puppetlabs.com/razor/v1/collections/policies","id":"http://localhost:8080/api/collections/policies"},{"name":"nodes","rel":"http://api.puppetlabs.com/razor/v1/collections/nodes","id":"http://localhost:8080/api/collections/nodes"},{"name":"tasks","rel":"http://api.puppetlabs.com/razor/v1/collections/tasks","id":"http://localhost:8080/api/collections/tasks"},{"name":"commands","rel":"http://api.puppetlabs.com/razor/v1/collections/commands","id":"http://localhost:8080/api/collections/commands"}],"version":{"server":"v0.14.1-113-g8b33d83-dirty"}}'
+      string: '{"commands":[{"name":"add-policy-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/add-policy-tag","id":"http://localhost:8080/api/commands/add-policy-tag"},{"name":"create-broker","rel":"http://api.puppetlabs.com/razor/v1/commands/create-broker","id":"http://localhost:8080/api/commands/create-broker"},{"name":"create-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/create-policy","id":"http://localhost:8080/api/commands/create-policy"},{"name":"create-repo","rel":"http://api.puppetlabs.com/razor/v1/commands/create-repo","id":"http://localhost:8080/api/commands/create-repo"},{"name":"create-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/create-tag","id":"http://localhost:8080/api/commands/create-tag"},{"name":"create-task","rel":"http://api.puppetlabs.com/razor/v1/commands/create-task","id":"http://localhost:8080/api/commands/create-task"},{"name":"delete-broker","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-broker","id":"http://localhost:8080/api/commands/delete-broker"},{"name":"delete-node","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-node","id":"http://localhost:8080/api/commands/delete-node"},{"name":"delete-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-policy","id":"http://localhost:8080/api/commands/delete-policy"},{"name":"delete-repo","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-repo","id":"http://localhost:8080/api/commands/delete-repo"},{"name":"delete-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-tag","id":"http://localhost:8080/api/commands/delete-tag"},{"name":"disable-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/disable-policy","id":"http://localhost:8080/api/commands/disable-policy"},{"name":"enable-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/enable-policy","id":"http://localhost:8080/api/commands/enable-policy"},{"name":"modify-node-metadata","rel":"http://api.puppetlabs.com/razor/v1/commands/modify-node-metadata","id":"http://localhost:8080/api/commands/modify-node-metadata"},{"name":"modify-policy-max-count","rel":"http://api.puppetlabs.com/razor/v1/commands/modify-policy-max-count","id":"http://localhost:8080/api/commands/modify-policy-max-count"},{"name":"move-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/move-policy","id":"http://localhost:8080/api/commands/move-policy"},{"name":"reboot-node","rel":"http://api.puppetlabs.com/razor/v1/commands/reboot-node","id":"http://localhost:8080/api/commands/reboot-node"},{"name":"register-node","rel":"http://api.puppetlabs.com/razor/v1/commands/register-node","id":"http://localhost:8080/api/commands/register-node"},{"name":"reinstall-node","rel":"http://api.puppetlabs.com/razor/v1/commands/reinstall-node","id":"http://localhost:8080/api/commands/reinstall-node"},{"name":"remove-node-metadata","rel":"http://api.puppetlabs.com/razor/v1/commands/remove-node-metadata","id":"http://localhost:8080/api/commands/remove-node-metadata"},{"name":"remove-policy-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/remove-policy-tag","id":"http://localhost:8080/api/commands/remove-policy-tag"},{"name":"set-node-desired-power-state","rel":"http://api.puppetlabs.com/razor/v1/commands/set-node-desired-power-state","id":"http://localhost:8080/api/commands/set-node-desired-power-state"},{"name":"set-node-hw-info","rel":"http://api.puppetlabs.com/razor/v1/commands/set-node-hw-info","id":"http://localhost:8080/api/commands/set-node-hw-info"},{"name":"set-node-ipmi-credentials","rel":"http://api.puppetlabs.com/razor/v1/commands/set-node-ipmi-credentials","id":"http://localhost:8080/api/commands/set-node-ipmi-credentials"},{"name":"update-node-metadata","rel":"http://api.puppetlabs.com/razor/v1/commands/update-node-metadata","id":"http://localhost:8080/api/commands/update-node-metadata"},{"name":"update-tag-rule","rel":"http://api.puppetlabs.com/razor/v1/commands/update-tag-rule","id":"http://localhost:8080/api/commands/update-tag-rule"}],"collections":[{"name":"brokers","rel":"http://api.puppetlabs.com/razor/v1/collections/brokers","id":"http://localhost:8080/api/collections/brokers"},{"name":"repos","rel":"http://api.puppetlabs.com/razor/v1/collections/repos","id":"http://localhost:8080/api/collections/repos"},{"name":"tags","rel":"http://api.puppetlabs.com/razor/v1/collections/tags","id":"http://localhost:8080/api/collections/tags"},{"name":"policies","rel":"http://api.puppetlabs.com/razor/v1/collections/policies","id":"http://localhost:8080/api/collections/policies"},{"name":"nodes","rel":"http://api.puppetlabs.com/razor/v1/collections/nodes","id":"http://localhost:8080/api/collections/nodes"},{"name":"tasks","rel":"http://api.puppetlabs.com/razor/v1/collections/tasks","id":"http://localhost:8080/api/collections/tasks"},{"name":"commands","rel":"http://api.puppetlabs.com/razor/v1/collections/commands","id":"http://localhost:8080/api/collections/commands"}],"version":{"server":"v0.15.0-26-gfffaba4-dirty"}}'
     http_version:
-  recorded_at: Fri, 16 May 2014 22:18:34 GMT
+  recorded_at: Thu, 14 Aug 2014 20:50:00 GMT
 - request:
     method: get
     uri: http://localhost:8080/api/commands/create-broker
@@ -54,23 +54,23 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       Etag:
-      - '"server-version-v0.14.1-113-g8b33d83-dirty"'
+      - '"server-version-v0.15.0-26-gfffaba4-dirty"'
       X-Content-Type-Options:
       - nosniff
       Content-Type:
       - application/json;charset=utf-8
       Content-Length:
-      - '2496'
+      - '2568'
       Date:
-      - Fri, 16 May 2014 22:18:33 GMT
+      - Thu, 14 Aug 2014 20:50:00 GMT
     body:
       encoding: US-ASCII
       string: '{"name":"create-broker","help":{"full":"# SYNOPSIS\nCreate a new broker
         configuration for hand-off of installed nodes\n\n# DESCRIPTION\nCreate a new
         broker configuration.  Brokers are responsible for handing a node\noff to
         a config management system, such as Puppet or Chef.  In cases where you\nhave
-        no configuration management system, you can use the `noop` broker.\n\n\n#
-        Access Control\n\nThis command''s access control pattern: `commands:create-broker:%{name}`\n\nWords
+        no configuration management system, you can use the `noop` broker.\n\n# Access
+        Control\n\nThis command''s access control pattern: `commands:create-broker:%{name}`\n\nWords
         surrounded by `%{...}` are substitutions from the input data: typically\nthe
         name of the object being modified, or some other critical detail, these\nallow
         roles to be granted partial access to modify the system.\n\nFor more detail
@@ -80,23 +80,24 @@ http_interactions:
         apply if security is enabled in the Razor configuration\nfile; on this server
         security is currently disabled.\n\n[shiro]: http://shiro.apache.org/permissions.html\n\n#
         Attributes\n\n * name\n   - The name of the broker, as it will be referenced
-        within Razor.\n   This is the name that you supply to, eg, `create-policy`
-        to specify\n   which broker the node will be handed off via after installation.\n   -
-        This attribute is required\n   - It must be of type string.\n   - It must
-        be between 1 and 250 in length.\n\n * broker-type\n   - The broker type that
-        this broker is created from.  The available\n   broker types on your server
-        are:\n        - chef\n    - noop\n    - puppet-pe\n    - puppet\n   - This
-        attribute is required\n   - It must be of type string.\n   - It must match
+        within Razor.\n     This is the name that you supply to, eg, `create-policy`
+        to specify\n     which broker the node will be handed off via after installation.\n   -
+        This attribute is required.\n   - It must be of type string.\n   - It must
+        be between 1 and 250 in length.\n\n * broker-type\n   - The broker type from
+        which this broker is created.  The available\n     broker types on your server
+        are:\n     - chef\n     - noop\n     - puppet-pe\n     - puppet\n   - This
+        attribute is required.\n   - It must be of type string.\n   - It must match
         the name of an existing broker type.\n\n * configuration\n   - The configuration
-        for the broker.  The acceptable values here are\n   determined by the `broker-type`
-        selected.  In general this has\n   settings like which server to contact,
-        and other configuration\n   related to handing on the newly installed system
-        to the final\n   configuration management system.\n   - It must be of type
-        object.\n   \n   \n\n\n\n# EXAMPLES\n  Creating a simple Puppet broker:\n  \n  {\n    \"name\":
-        \"puppet\",\n    \"configuration\": {\n       \"server\":      \"puppet.example.org\",\n       \"environment\":
-        \"production\"\n    },\n    \"broker-type\": \"puppet\"\n  }\n\n"},"schema":{"name":{"type":"string"},"broker-type":{"type":"string"},"configuration":{"type":"object"}}}'
+        for the broker.  The acceptable values here are\n     determined by the `broker-type`
+        selected.  In general this has\n     settings like which server to contact,
+        and other configuration\n     related to handing on the newly installed system
+        to the final\n     configuration management system.\n     \n     This attribute
+        can be abbreviated as `c` for convenience.\n   - It must be of type object.\n\n#
+        EXAMPLES\n\n  Creating a simple Puppet broker:\n  \n  {\n    \"name\": \"puppet\",\n    \"configuration\":
+        {\n       \"server\":      \"puppet.example.org\",\n       \"environment\":
+        \"production\"\n    },\n    \"broker-type\": \"puppet\"\n  }\n"},"schema":{"name":{"type":"string"},"broker-type":{"type":"string"},"configuration":{"type":"object"}}}'
     http_version:
-  recorded_at: Fri, 16 May 2014 22:18:34 GMT
+  recorded_at: Thu, 14 Aug 2014 20:50:00 GMT
 - request:
     method: get
     uri: http://localhost:8080/api/commands/create-broker
@@ -118,23 +119,23 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       Etag:
-      - '"server-version-v0.14.1-113-g8b33d83-dirty"'
+      - '"server-version-v0.15.0-26-gfffaba4-dirty"'
       X-Content-Type-Options:
       - nosniff
       Content-Type:
       - application/json;charset=utf-8
       Content-Length:
-      - '2496'
+      - '2568'
       Date:
-      - Fri, 16 May 2014 22:18:33 GMT
+      - Thu, 14 Aug 2014 20:50:00 GMT
     body:
       encoding: US-ASCII
       string: '{"name":"create-broker","help":{"full":"# SYNOPSIS\nCreate a new broker
         configuration for hand-off of installed nodes\n\n# DESCRIPTION\nCreate a new
         broker configuration.  Brokers are responsible for handing a node\noff to
         a config management system, such as Puppet or Chef.  In cases where you\nhave
-        no configuration management system, you can use the `noop` broker.\n\n\n#
-        Access Control\n\nThis command''s access control pattern: `commands:create-broker:%{name}`\n\nWords
+        no configuration management system, you can use the `noop` broker.\n\n# Access
+        Control\n\nThis command''s access control pattern: `commands:create-broker:%{name}`\n\nWords
         surrounded by `%{...}` are substitutions from the input data: typically\nthe
         name of the object being modified, or some other critical detail, these\nallow
         roles to be granted partial access to modify the system.\n\nFor more detail
@@ -144,23 +145,24 @@ http_interactions:
         apply if security is enabled in the Razor configuration\nfile; on this server
         security is currently disabled.\n\n[shiro]: http://shiro.apache.org/permissions.html\n\n#
         Attributes\n\n * name\n   - The name of the broker, as it will be referenced
-        within Razor.\n   This is the name that you supply to, eg, `create-policy`
-        to specify\n   which broker the node will be handed off via after installation.\n   -
-        This attribute is required\n   - It must be of type string.\n   - It must
-        be between 1 and 250 in length.\n\n * broker-type\n   - The broker type that
-        this broker is created from.  The available\n   broker types on your server
-        are:\n        - chef\n    - noop\n    - puppet-pe\n    - puppet\n   - This
-        attribute is required\n   - It must be of type string.\n   - It must match
+        within Razor.\n     This is the name that you supply to, eg, `create-policy`
+        to specify\n     which broker the node will be handed off via after installation.\n   -
+        This attribute is required.\n   - It must be of type string.\n   - It must
+        be between 1 and 250 in length.\n\n * broker-type\n   - The broker type from
+        which this broker is created.  The available\n     broker types on your server
+        are:\n     - chef\n     - noop\n     - puppet-pe\n     - puppet\n   - This
+        attribute is required.\n   - It must be of type string.\n   - It must match
         the name of an existing broker type.\n\n * configuration\n   - The configuration
-        for the broker.  The acceptable values here are\n   determined by the `broker-type`
-        selected.  In general this has\n   settings like which server to contact,
-        and other configuration\n   related to handing on the newly installed system
-        to the final\n   configuration management system.\n   - It must be of type
-        object.\n   \n   \n\n\n\n# EXAMPLES\n  Creating a simple Puppet broker:\n  \n  {\n    \"name\":
-        \"puppet\",\n    \"configuration\": {\n       \"server\":      \"puppet.example.org\",\n       \"environment\":
-        \"production\"\n    },\n    \"broker-type\": \"puppet\"\n  }\n\n"},"schema":{"name":{"type":"string"},"broker-type":{"type":"string"},"configuration":{"type":"object"}}}'
+        for the broker.  The acceptable values here are\n     determined by the `broker-type`
+        selected.  In general this has\n     settings like which server to contact,
+        and other configuration\n     related to handing on the newly installed system
+        to the final\n     configuration management system.\n     \n     This attribute
+        can be abbreviated as `c` for convenience.\n   - It must be of type object.\n\n#
+        EXAMPLES\n\n  Creating a simple Puppet broker:\n  \n  {\n    \"name\": \"puppet\",\n    \"configuration\":
+        {\n       \"server\":      \"puppet.example.org\",\n       \"environment\":
+        \"production\"\n    },\n    \"broker-type\": \"puppet\"\n  }\n"},"schema":{"name":{"type":"string"},"broker-type":{"type":"string"},"configuration":{"type":"object"}}}'
     http_version:
-  recorded_at: Fri, 16 May 2014 22:18:34 GMT
+  recorded_at: Thu, 14 Aug 2014 20:50:00 GMT
 - request:
     method: get
     uri: http://localhost:8080/api/commands/create-broker
@@ -182,23 +184,23 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       Etag:
-      - '"server-version-v0.14.1-113-g8b33d83-dirty"'
+      - '"server-version-v0.15.0-26-gfffaba4-dirty"'
       X-Content-Type-Options:
       - nosniff
       Content-Type:
       - application/json;charset=utf-8
       Content-Length:
-      - '2496'
+      - '2568'
       Date:
-      - Fri, 16 May 2014 22:18:33 GMT
+      - Thu, 14 Aug 2014 20:50:00 GMT
     body:
       encoding: US-ASCII
       string: '{"name":"create-broker","help":{"full":"# SYNOPSIS\nCreate a new broker
         configuration for hand-off of installed nodes\n\n# DESCRIPTION\nCreate a new
         broker configuration.  Brokers are responsible for handing a node\noff to
         a config management system, such as Puppet or Chef.  In cases where you\nhave
-        no configuration management system, you can use the `noop` broker.\n\n\n#
-        Access Control\n\nThis command''s access control pattern: `commands:create-broker:%{name}`\n\nWords
+        no configuration management system, you can use the `noop` broker.\n\n# Access
+        Control\n\nThis command''s access control pattern: `commands:create-broker:%{name}`\n\nWords
         surrounded by `%{...}` are substitutions from the input data: typically\nthe
         name of the object being modified, or some other critical detail, these\nallow
         roles to be granted partial access to modify the system.\n\nFor more detail
@@ -208,21 +210,22 @@ http_interactions:
         apply if security is enabled in the Razor configuration\nfile; on this server
         security is currently disabled.\n\n[shiro]: http://shiro.apache.org/permissions.html\n\n#
         Attributes\n\n * name\n   - The name of the broker, as it will be referenced
-        within Razor.\n   This is the name that you supply to, eg, `create-policy`
-        to specify\n   which broker the node will be handed off via after installation.\n   -
-        This attribute is required\n   - It must be of type string.\n   - It must
-        be between 1 and 250 in length.\n\n * broker-type\n   - The broker type that
-        this broker is created from.  The available\n   broker types on your server
-        are:\n        - chef\n    - noop\n    - puppet-pe\n    - puppet\n   - This
-        attribute is required\n   - It must be of type string.\n   - It must match
+        within Razor.\n     This is the name that you supply to, eg, `create-policy`
+        to specify\n     which broker the node will be handed off via after installation.\n   -
+        This attribute is required.\n   - It must be of type string.\n   - It must
+        be between 1 and 250 in length.\n\n * broker-type\n   - The broker type from
+        which this broker is created.  The available\n     broker types on your server
+        are:\n     - chef\n     - noop\n     - puppet-pe\n     - puppet\n   - This
+        attribute is required.\n   - It must be of type string.\n   - It must match
         the name of an existing broker type.\n\n * configuration\n   - The configuration
-        for the broker.  The acceptable values here are\n   determined by the `broker-type`
-        selected.  In general this has\n   settings like which server to contact,
-        and other configuration\n   related to handing on the newly installed system
-        to the final\n   configuration management system.\n   - It must be of type
-        object.\n   \n   \n\n\n\n# EXAMPLES\n  Creating a simple Puppet broker:\n  \n  {\n    \"name\":
-        \"puppet\",\n    \"configuration\": {\n       \"server\":      \"puppet.example.org\",\n       \"environment\":
-        \"production\"\n    },\n    \"broker-type\": \"puppet\"\n  }\n\n"},"schema":{"name":{"type":"string"},"broker-type":{"type":"string"},"configuration":{"type":"object"}}}'
+        for the broker.  The acceptable values here are\n     determined by the `broker-type`
+        selected.  In general this has\n     settings like which server to contact,
+        and other configuration\n     related to handing on the newly installed system
+        to the final\n     configuration management system.\n     \n     This attribute
+        can be abbreviated as `c` for convenience.\n   - It must be of type object.\n\n#
+        EXAMPLES\n\n  Creating a simple Puppet broker:\n  \n  {\n    \"name\": \"puppet\",\n    \"configuration\":
+        {\n       \"server\":      \"puppet.example.org\",\n       \"environment\":
+        \"production\"\n    },\n    \"broker-type\": \"puppet\"\n  }\n"},"schema":{"name":{"type":"string"},"broker-type":{"type":"string"},"configuration":{"type":"object"}}}'
     http_version:
-  recorded_at: Fri, 16 May 2014 22:18:34 GMT
-recorded_with: VCR 2.5.0
+  recorded_at: Thu, 14 Aug 2014 20:50:01 GMT
+recorded_with: VCR 2.9.2

--- a/spec/fixtures/vcr/Razor_CLI_Navigate/with_multiple_arguments_with_same_name/combining_as_an_object/should_fail_with_mixed_types_hash_then_array_.yml
+++ b/spec/fixtures/vcr/Razor_CLI_Navigate/with_multiple_arguments_with_same_name/combining_as_an_object/should_fail_with_mixed_types_hash_then_array_.yml
@@ -25,14 +25,14 @@ http_interactions:
       Content-Type:
       - application/json;charset=utf-8
       Content-Length:
-      - '4982'
+      - '4981'
       Date:
-      - Fri, 16 May 2014 22:18:39 GMT
+      - Thu, 14 Aug 2014 20:50:07 GMT
     body:
       encoding: US-ASCII
-      string: '{"commands":[{"name":"add-policy-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/add-policy-tag","id":"http://localhost:8080/api/commands/add-policy-tag"},{"name":"create-broker","rel":"http://api.puppetlabs.com/razor/v1/commands/create-broker","id":"http://localhost:8080/api/commands/create-broker"},{"name":"create-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/create-policy","id":"http://localhost:8080/api/commands/create-policy"},{"name":"create-repo","rel":"http://api.puppetlabs.com/razor/v1/commands/create-repo","id":"http://localhost:8080/api/commands/create-repo"},{"name":"create-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/create-tag","id":"http://localhost:8080/api/commands/create-tag"},{"name":"create-task","rel":"http://api.puppetlabs.com/razor/v1/commands/create-task","id":"http://localhost:8080/api/commands/create-task"},{"name":"delete-broker","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-broker","id":"http://localhost:8080/api/commands/delete-broker"},{"name":"delete-node","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-node","id":"http://localhost:8080/api/commands/delete-node"},{"name":"delete-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-policy","id":"http://localhost:8080/api/commands/delete-policy"},{"name":"delete-repo","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-repo","id":"http://localhost:8080/api/commands/delete-repo"},{"name":"delete-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-tag","id":"http://localhost:8080/api/commands/delete-tag"},{"name":"disable-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/disable-policy","id":"http://localhost:8080/api/commands/disable-policy"},{"name":"enable-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/enable-policy","id":"http://localhost:8080/api/commands/enable-policy"},{"name":"modify-node-metadata","rel":"http://api.puppetlabs.com/razor/v1/commands/modify-node-metadata","id":"http://localhost:8080/api/commands/modify-node-metadata"},{"name":"modify-policy-max-count","rel":"http://api.puppetlabs.com/razor/v1/commands/modify-policy-max-count","id":"http://localhost:8080/api/commands/modify-policy-max-count"},{"name":"move-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/move-policy","id":"http://localhost:8080/api/commands/move-policy"},{"name":"reboot-node","rel":"http://api.puppetlabs.com/razor/v1/commands/reboot-node","id":"http://localhost:8080/api/commands/reboot-node"},{"name":"register-node","rel":"http://api.puppetlabs.com/razor/v1/commands/register-node","id":"http://localhost:8080/api/commands/register-node"},{"name":"reinstall-node","rel":"http://api.puppetlabs.com/razor/v1/commands/reinstall-node","id":"http://localhost:8080/api/commands/reinstall-node"},{"name":"remove-node-metadata","rel":"http://api.puppetlabs.com/razor/v1/commands/remove-node-metadata","id":"http://localhost:8080/api/commands/remove-node-metadata"},{"name":"remove-policy-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/remove-policy-tag","id":"http://localhost:8080/api/commands/remove-policy-tag"},{"name":"set-node-desired-power-state","rel":"http://api.puppetlabs.com/razor/v1/commands/set-node-desired-power-state","id":"http://localhost:8080/api/commands/set-node-desired-power-state"},{"name":"set-node-hw-info","rel":"http://api.puppetlabs.com/razor/v1/commands/set-node-hw-info","id":"http://localhost:8080/api/commands/set-node-hw-info"},{"name":"set-node-ipmi-credentials","rel":"http://api.puppetlabs.com/razor/v1/commands/set-node-ipmi-credentials","id":"http://localhost:8080/api/commands/set-node-ipmi-credentials"},{"name":"update-node-metadata","rel":"http://api.puppetlabs.com/razor/v1/commands/update-node-metadata","id":"http://localhost:8080/api/commands/update-node-metadata"},{"name":"update-tag-rule","rel":"http://api.puppetlabs.com/razor/v1/commands/update-tag-rule","id":"http://localhost:8080/api/commands/update-tag-rule"}],"collections":[{"name":"brokers","rel":"http://api.puppetlabs.com/razor/v1/collections/brokers","id":"http://localhost:8080/api/collections/brokers"},{"name":"repos","rel":"http://api.puppetlabs.com/razor/v1/collections/repos","id":"http://localhost:8080/api/collections/repos"},{"name":"tags","rel":"http://api.puppetlabs.com/razor/v1/collections/tags","id":"http://localhost:8080/api/collections/tags"},{"name":"policies","rel":"http://api.puppetlabs.com/razor/v1/collections/policies","id":"http://localhost:8080/api/collections/policies"},{"name":"nodes","rel":"http://api.puppetlabs.com/razor/v1/collections/nodes","id":"http://localhost:8080/api/collections/nodes"},{"name":"tasks","rel":"http://api.puppetlabs.com/razor/v1/collections/tasks","id":"http://localhost:8080/api/collections/tasks"},{"name":"commands","rel":"http://api.puppetlabs.com/razor/v1/collections/commands","id":"http://localhost:8080/api/collections/commands"}],"version":{"server":"v0.14.1-113-g8b33d83-dirty"}}'
+      string: '{"commands":[{"name":"add-policy-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/add-policy-tag","id":"http://localhost:8080/api/commands/add-policy-tag"},{"name":"create-broker","rel":"http://api.puppetlabs.com/razor/v1/commands/create-broker","id":"http://localhost:8080/api/commands/create-broker"},{"name":"create-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/create-policy","id":"http://localhost:8080/api/commands/create-policy"},{"name":"create-repo","rel":"http://api.puppetlabs.com/razor/v1/commands/create-repo","id":"http://localhost:8080/api/commands/create-repo"},{"name":"create-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/create-tag","id":"http://localhost:8080/api/commands/create-tag"},{"name":"create-task","rel":"http://api.puppetlabs.com/razor/v1/commands/create-task","id":"http://localhost:8080/api/commands/create-task"},{"name":"delete-broker","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-broker","id":"http://localhost:8080/api/commands/delete-broker"},{"name":"delete-node","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-node","id":"http://localhost:8080/api/commands/delete-node"},{"name":"delete-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-policy","id":"http://localhost:8080/api/commands/delete-policy"},{"name":"delete-repo","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-repo","id":"http://localhost:8080/api/commands/delete-repo"},{"name":"delete-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-tag","id":"http://localhost:8080/api/commands/delete-tag"},{"name":"disable-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/disable-policy","id":"http://localhost:8080/api/commands/disable-policy"},{"name":"enable-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/enable-policy","id":"http://localhost:8080/api/commands/enable-policy"},{"name":"modify-node-metadata","rel":"http://api.puppetlabs.com/razor/v1/commands/modify-node-metadata","id":"http://localhost:8080/api/commands/modify-node-metadata"},{"name":"modify-policy-max-count","rel":"http://api.puppetlabs.com/razor/v1/commands/modify-policy-max-count","id":"http://localhost:8080/api/commands/modify-policy-max-count"},{"name":"move-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/move-policy","id":"http://localhost:8080/api/commands/move-policy"},{"name":"reboot-node","rel":"http://api.puppetlabs.com/razor/v1/commands/reboot-node","id":"http://localhost:8080/api/commands/reboot-node"},{"name":"register-node","rel":"http://api.puppetlabs.com/razor/v1/commands/register-node","id":"http://localhost:8080/api/commands/register-node"},{"name":"reinstall-node","rel":"http://api.puppetlabs.com/razor/v1/commands/reinstall-node","id":"http://localhost:8080/api/commands/reinstall-node"},{"name":"remove-node-metadata","rel":"http://api.puppetlabs.com/razor/v1/commands/remove-node-metadata","id":"http://localhost:8080/api/commands/remove-node-metadata"},{"name":"remove-policy-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/remove-policy-tag","id":"http://localhost:8080/api/commands/remove-policy-tag"},{"name":"set-node-desired-power-state","rel":"http://api.puppetlabs.com/razor/v1/commands/set-node-desired-power-state","id":"http://localhost:8080/api/commands/set-node-desired-power-state"},{"name":"set-node-hw-info","rel":"http://api.puppetlabs.com/razor/v1/commands/set-node-hw-info","id":"http://localhost:8080/api/commands/set-node-hw-info"},{"name":"set-node-ipmi-credentials","rel":"http://api.puppetlabs.com/razor/v1/commands/set-node-ipmi-credentials","id":"http://localhost:8080/api/commands/set-node-ipmi-credentials"},{"name":"update-node-metadata","rel":"http://api.puppetlabs.com/razor/v1/commands/update-node-metadata","id":"http://localhost:8080/api/commands/update-node-metadata"},{"name":"update-tag-rule","rel":"http://api.puppetlabs.com/razor/v1/commands/update-tag-rule","id":"http://localhost:8080/api/commands/update-tag-rule"}],"collections":[{"name":"brokers","rel":"http://api.puppetlabs.com/razor/v1/collections/brokers","id":"http://localhost:8080/api/collections/brokers"},{"name":"repos","rel":"http://api.puppetlabs.com/razor/v1/collections/repos","id":"http://localhost:8080/api/collections/repos"},{"name":"tags","rel":"http://api.puppetlabs.com/razor/v1/collections/tags","id":"http://localhost:8080/api/collections/tags"},{"name":"policies","rel":"http://api.puppetlabs.com/razor/v1/collections/policies","id":"http://localhost:8080/api/collections/policies"},{"name":"nodes","rel":"http://api.puppetlabs.com/razor/v1/collections/nodes","id":"http://localhost:8080/api/collections/nodes"},{"name":"tasks","rel":"http://api.puppetlabs.com/razor/v1/collections/tasks","id":"http://localhost:8080/api/collections/tasks"},{"name":"commands","rel":"http://api.puppetlabs.com/razor/v1/collections/commands","id":"http://localhost:8080/api/collections/commands"}],"version":{"server":"v0.15.0-26-gfffaba4-dirty"}}'
     http_version:
-  recorded_at: Fri, 16 May 2014 22:18:39 GMT
+  recorded_at: Thu, 14 Aug 2014 20:50:07 GMT
 - request:
     method: get
     uri: http://localhost:8080/api/commands/create-broker
@@ -54,23 +54,23 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       Etag:
-      - '"server-version-v0.14.1-113-g8b33d83-dirty"'
+      - '"server-version-v0.15.0-26-gfffaba4-dirty"'
       X-Content-Type-Options:
       - nosniff
       Content-Type:
       - application/json;charset=utf-8
       Content-Length:
-      - '2496'
+      - '2568'
       Date:
-      - Fri, 16 May 2014 22:18:39 GMT
+      - Thu, 14 Aug 2014 20:50:07 GMT
     body:
       encoding: US-ASCII
       string: '{"name":"create-broker","help":{"full":"# SYNOPSIS\nCreate a new broker
         configuration for hand-off of installed nodes\n\n# DESCRIPTION\nCreate a new
         broker configuration.  Brokers are responsible for handing a node\noff to
         a config management system, such as Puppet or Chef.  In cases where you\nhave
-        no configuration management system, you can use the `noop` broker.\n\n\n#
-        Access Control\n\nThis command''s access control pattern: `commands:create-broker:%{name}`\n\nWords
+        no configuration management system, you can use the `noop` broker.\n\n# Access
+        Control\n\nThis command''s access control pattern: `commands:create-broker:%{name}`\n\nWords
         surrounded by `%{...}` are substitutions from the input data: typically\nthe
         name of the object being modified, or some other critical detail, these\nallow
         roles to be granted partial access to modify the system.\n\nFor more detail
@@ -80,23 +80,24 @@ http_interactions:
         apply if security is enabled in the Razor configuration\nfile; on this server
         security is currently disabled.\n\n[shiro]: http://shiro.apache.org/permissions.html\n\n#
         Attributes\n\n * name\n   - The name of the broker, as it will be referenced
-        within Razor.\n   This is the name that you supply to, eg, `create-policy`
-        to specify\n   which broker the node will be handed off via after installation.\n   -
-        This attribute is required\n   - It must be of type string.\n   - It must
-        be between 1 and 250 in length.\n\n * broker-type\n   - The broker type that
-        this broker is created from.  The available\n   broker types on your server
-        are:\n        - chef\n    - noop\n    - puppet-pe\n    - puppet\n   - This
-        attribute is required\n   - It must be of type string.\n   - It must match
+        within Razor.\n     This is the name that you supply to, eg, `create-policy`
+        to specify\n     which broker the node will be handed off via after installation.\n   -
+        This attribute is required.\n   - It must be of type string.\n   - It must
+        be between 1 and 250 in length.\n\n * broker-type\n   - The broker type from
+        which this broker is created.  The available\n     broker types on your server
+        are:\n     - chef\n     - noop\n     - puppet-pe\n     - puppet\n   - This
+        attribute is required.\n   - It must be of type string.\n   - It must match
         the name of an existing broker type.\n\n * configuration\n   - The configuration
-        for the broker.  The acceptable values here are\n   determined by the `broker-type`
-        selected.  In general this has\n   settings like which server to contact,
-        and other configuration\n   related to handing on the newly installed system
-        to the final\n   configuration management system.\n   - It must be of type
-        object.\n   \n   \n\n\n\n# EXAMPLES\n  Creating a simple Puppet broker:\n  \n  {\n    \"name\":
-        \"puppet\",\n    \"configuration\": {\n       \"server\":      \"puppet.example.org\",\n       \"environment\":
-        \"production\"\n    },\n    \"broker-type\": \"puppet\"\n  }\n\n"},"schema":{"name":{"type":"string"},"broker-type":{"type":"string"},"configuration":{"type":"object"}}}'
+        for the broker.  The acceptable values here are\n     determined by the `broker-type`
+        selected.  In general this has\n     settings like which server to contact,
+        and other configuration\n     related to handing on the newly installed system
+        to the final\n     configuration management system.\n     \n     This attribute
+        can be abbreviated as `c` for convenience.\n   - It must be of type object.\n\n#
+        EXAMPLES\n\n  Creating a simple Puppet broker:\n  \n  {\n    \"name\": \"puppet\",\n    \"configuration\":
+        {\n       \"server\":      \"puppet.example.org\",\n       \"environment\":
+        \"production\"\n    },\n    \"broker-type\": \"puppet\"\n  }\n"},"schema":{"name":{"type":"string"},"broker-type":{"type":"string"},"configuration":{"type":"object"}}}'
     http_version:
-  recorded_at: Fri, 16 May 2014 22:18:39 GMT
+  recorded_at: Thu, 14 Aug 2014 20:50:07 GMT
 - request:
     method: get
     uri: http://localhost:8080/api/commands/create-broker
@@ -118,23 +119,23 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       Etag:
-      - '"server-version-v0.14.1-113-g8b33d83-dirty"'
+      - '"server-version-v0.15.0-26-gfffaba4-dirty"'
       X-Content-Type-Options:
       - nosniff
       Content-Type:
       - application/json;charset=utf-8
       Content-Length:
-      - '2496'
+      - '2568'
       Date:
-      - Fri, 16 May 2014 22:18:39 GMT
+      - Thu, 14 Aug 2014 20:50:07 GMT
     body:
       encoding: US-ASCII
       string: '{"name":"create-broker","help":{"full":"# SYNOPSIS\nCreate a new broker
         configuration for hand-off of installed nodes\n\n# DESCRIPTION\nCreate a new
         broker configuration.  Brokers are responsible for handing a node\noff to
         a config management system, such as Puppet or Chef.  In cases where you\nhave
-        no configuration management system, you can use the `noop` broker.\n\n\n#
-        Access Control\n\nThis command''s access control pattern: `commands:create-broker:%{name}`\n\nWords
+        no configuration management system, you can use the `noop` broker.\n\n# Access
+        Control\n\nThis command''s access control pattern: `commands:create-broker:%{name}`\n\nWords
         surrounded by `%{...}` are substitutions from the input data: typically\nthe
         name of the object being modified, or some other critical detail, these\nallow
         roles to be granted partial access to modify the system.\n\nFor more detail
@@ -144,21 +145,152 @@ http_interactions:
         apply if security is enabled in the Razor configuration\nfile; on this server
         security is currently disabled.\n\n[shiro]: http://shiro.apache.org/permissions.html\n\n#
         Attributes\n\n * name\n   - The name of the broker, as it will be referenced
-        within Razor.\n   This is the name that you supply to, eg, `create-policy`
-        to specify\n   which broker the node will be handed off via after installation.\n   -
-        This attribute is required\n   - It must be of type string.\n   - It must
-        be between 1 and 250 in length.\n\n * broker-type\n   - The broker type that
-        this broker is created from.  The available\n   broker types on your server
-        are:\n        - chef\n    - noop\n    - puppet-pe\n    - puppet\n   - This
-        attribute is required\n   - It must be of type string.\n   - It must match
+        within Razor.\n     This is the name that you supply to, eg, `create-policy`
+        to specify\n     which broker the node will be handed off via after installation.\n   -
+        This attribute is required.\n   - It must be of type string.\n   - It must
+        be between 1 and 250 in length.\n\n * broker-type\n   - The broker type from
+        which this broker is created.  The available\n     broker types on your server
+        are:\n     - chef\n     - noop\n     - puppet-pe\n     - puppet\n   - This
+        attribute is required.\n   - It must be of type string.\n   - It must match
         the name of an existing broker type.\n\n * configuration\n   - The configuration
-        for the broker.  The acceptable values here are\n   determined by the `broker-type`
-        selected.  In general this has\n   settings like which server to contact,
-        and other configuration\n   related to handing on the newly installed system
-        to the final\n   configuration management system.\n   - It must be of type
-        object.\n   \n   \n\n\n\n# EXAMPLES\n  Creating a simple Puppet broker:\n  \n  {\n    \"name\":
-        \"puppet\",\n    \"configuration\": {\n       \"server\":      \"puppet.example.org\",\n       \"environment\":
-        \"production\"\n    },\n    \"broker-type\": \"puppet\"\n  }\n\n"},"schema":{"name":{"type":"string"},"broker-type":{"type":"string"},"configuration":{"type":"object"}}}'
+        for the broker.  The acceptable values here are\n     determined by the `broker-type`
+        selected.  In general this has\n     settings like which server to contact,
+        and other configuration\n     related to handing on the newly installed system
+        to the final\n     configuration management system.\n     \n     This attribute
+        can be abbreviated as `c` for convenience.\n   - It must be of type object.\n\n#
+        EXAMPLES\n\n  Creating a simple Puppet broker:\n  \n  {\n    \"name\": \"puppet\",\n    \"configuration\":
+        {\n       \"server\":      \"puppet.example.org\",\n       \"environment\":
+        \"production\"\n    },\n    \"broker-type\": \"puppet\"\n  }\n"},"schema":{"name":{"type":"string"},"broker-type":{"type":"string"},"configuration":{"type":"object"}}}'
     http_version:
-  recorded_at: Fri, 16 May 2014 22:18:39 GMT
-recorded_with: VCR 2.5.0
+  recorded_at: Thu, 14 Aug 2014 20:50:08 GMT
+- request:
+    method: get
+    uri: http://localhost:8080/api/commands/create-broker
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Etag:
+      - '"server-version-v0.15.0-26-gfffaba4-dirty"'
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json;charset=utf-8
+      Content-Length:
+      - '2568'
+      Date:
+      - Thu, 14 Aug 2014 20:50:07 GMT
+    body:
+      encoding: US-ASCII
+      string: '{"name":"create-broker","help":{"full":"# SYNOPSIS\nCreate a new broker
+        configuration for hand-off of installed nodes\n\n# DESCRIPTION\nCreate a new
+        broker configuration.  Brokers are responsible for handing a node\noff to
+        a config management system, such as Puppet or Chef.  In cases where you\nhave
+        no configuration management system, you can use the `noop` broker.\n\n# Access
+        Control\n\nThis command''s access control pattern: `commands:create-broker:%{name}`\n\nWords
+        surrounded by `%{...}` are substitutions from the input data: typically\nthe
+        name of the object being modified, or some other critical detail, these\nallow
+        roles to be granted partial access to modify the system.\n\nFor more detail
+        on how the permission strings are structured and work, you can\nsee the [Shiro
+        Permissions documentation][shiro].  That pattern is expanded\nand then a permission
+        check applied to it, before the command is authorized.\n\nThese checks only
+        apply if security is enabled in the Razor configuration\nfile; on this server
+        security is currently disabled.\n\n[shiro]: http://shiro.apache.org/permissions.html\n\n#
+        Attributes\n\n * name\n   - The name of the broker, as it will be referenced
+        within Razor.\n     This is the name that you supply to, eg, `create-policy`
+        to specify\n     which broker the node will be handed off via after installation.\n   -
+        This attribute is required.\n   - It must be of type string.\n   - It must
+        be between 1 and 250 in length.\n\n * broker-type\n   - The broker type from
+        which this broker is created.  The available\n     broker types on your server
+        are:\n     - chef\n     - noop\n     - puppet-pe\n     - puppet\n   - This
+        attribute is required.\n   - It must be of type string.\n   - It must match
+        the name of an existing broker type.\n\n * configuration\n   - The configuration
+        for the broker.  The acceptable values here are\n     determined by the `broker-type`
+        selected.  In general this has\n     settings like which server to contact,
+        and other configuration\n     related to handing on the newly installed system
+        to the final\n     configuration management system.\n     \n     This attribute
+        can be abbreviated as `c` for convenience.\n   - It must be of type object.\n\n#
+        EXAMPLES\n\n  Creating a simple Puppet broker:\n  \n  {\n    \"name\": \"puppet\",\n    \"configuration\":
+        {\n       \"server\":      \"puppet.example.org\",\n       \"environment\":
+        \"production\"\n    },\n    \"broker-type\": \"puppet\"\n  }\n"},"schema":{"name":{"type":"string"},"broker-type":{"type":"string"},"configuration":{"type":"object"}}}'
+    http_version:
+  recorded_at: Thu, 14 Aug 2014 20:50:08 GMT
+- request:
+    method: get
+    uri: http://localhost:8080/api/commands/create-broker
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Etag:
+      - '"server-version-v0.15.0-26-gfffaba4-dirty"'
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json;charset=utf-8
+      Content-Length:
+      - '2568'
+      Date:
+      - Thu, 14 Aug 2014 20:50:07 GMT
+    body:
+      encoding: US-ASCII
+      string: '{"name":"create-broker","help":{"full":"# SYNOPSIS\nCreate a new broker
+        configuration for hand-off of installed nodes\n\n# DESCRIPTION\nCreate a new
+        broker configuration.  Brokers are responsible for handing a node\noff to
+        a config management system, such as Puppet or Chef.  In cases where you\nhave
+        no configuration management system, you can use the `noop` broker.\n\n# Access
+        Control\n\nThis command''s access control pattern: `commands:create-broker:%{name}`\n\nWords
+        surrounded by `%{...}` are substitutions from the input data: typically\nthe
+        name of the object being modified, or some other critical detail, these\nallow
+        roles to be granted partial access to modify the system.\n\nFor more detail
+        on how the permission strings are structured and work, you can\nsee the [Shiro
+        Permissions documentation][shiro].  That pattern is expanded\nand then a permission
+        check applied to it, before the command is authorized.\n\nThese checks only
+        apply if security is enabled in the Razor configuration\nfile; on this server
+        security is currently disabled.\n\n[shiro]: http://shiro.apache.org/permissions.html\n\n#
+        Attributes\n\n * name\n   - The name of the broker, as it will be referenced
+        within Razor.\n     This is the name that you supply to, eg, `create-policy`
+        to specify\n     which broker the node will be handed off via after installation.\n   -
+        This attribute is required.\n   - It must be of type string.\n   - It must
+        be between 1 and 250 in length.\n\n * broker-type\n   - The broker type from
+        which this broker is created.  The available\n     broker types on your server
+        are:\n     - chef\n     - noop\n     - puppet-pe\n     - puppet\n   - This
+        attribute is required.\n   - It must be of type string.\n   - It must match
+        the name of an existing broker type.\n\n * configuration\n   - The configuration
+        for the broker.  The acceptable values here are\n     determined by the `broker-type`
+        selected.  In general this has\n     settings like which server to contact,
+        and other configuration\n     related to handing on the newly installed system
+        to the final\n     configuration management system.\n     \n     This attribute
+        can be abbreviated as `c` for convenience.\n   - It must be of type object.\n\n#
+        EXAMPLES\n\n  Creating a simple Puppet broker:\n  \n  {\n    \"name\": \"puppet\",\n    \"configuration\":
+        {\n       \"server\":      \"puppet.example.org\",\n       \"environment\":
+        \"production\"\n    },\n    \"broker-type\": \"puppet\"\n  }\n"},"schema":{"name":{"type":"string"},"broker-type":{"type":"string"},"configuration":{"type":"object"}}}'
+    http_version:
+  recorded_at: Thu, 14 Aug 2014 20:50:08 GMT
+recorded_with: VCR 2.9.2


### PR DESCRIPTION
Existing functionality failed if you tried to, for example, create
a name like "a=b". This fixes that by consolidating the logic around
the expected datatypes for each argument.

Fixes https://tickets.puppetlabs.com/browse/RAZOR-372
