### PR TITLE
Special display for API vs. CLI command help

### DIFF
--- a/lib/razor/cli/parse.rb
+++ b/lib/razor/cli/parse.rb
@@ -22,13 +22,17 @@ module Razor::CLI
           @format = 'full'
         end
 
+        opts.on "-a", "--api", "Show API help for a command" do
+          @api_help = true
+        end
+
         opts.on "-s", "--short", "Show shortened details when viewing entities" do
           @format = 'short'
         end
 
         opts.on "-k", "--insecure", "Allow SSL connections without verified certificates" do
-	  @verify_ssl = false
-	end
+          @verify_ssl = false
+        end
 
         opts.on "-u", "--url URL",
           "The full Razor API URL, can also be set\n" + " "*37 +
@@ -95,6 +99,10 @@ ERR
 
     def show_version?
       !!@show_version
+    end
+
+    def show_api_help?
+      !!@api_help
     end
 
     def show_help?

--- a/spec/cli/format_spec.rb
+++ b/spec/cli/format_spec.rb
@@ -15,7 +15,8 @@ describe Razor::CLI::Format do
   include described_class
 
   def format(doc, args = {})
-    args = {:format => 'short', :args => ['something', 'else'], :query? => true, :show_command_help? => false}.merge(args)
+    args = {:format => 'short', :args => ['something', 'else'], :query? => true, :show_command_help? => false,
+        :show_api_help? => false}.merge(args)
     parse = double(args)
     format_document doc, parse
   end
@@ -133,6 +134,50 @@ describe Razor::CLI::Format do
 | ᓱᓴᓐ ᐊᒡᓗᒃᑲᖅ |\s
 +------------+
 OUTPUT
+    end
+  end
+
+  context 'api help' do
+    it "displays the CLI help by default" do
+      doc = {"name"=>"some-help", "help" => {"summary"=>"summary here",
+                                             "examples"=>{"api"=>"api example is here", "cli"=>"cli example is here"},
+                                             "full" => "shouldn't show this"},
+             "schema" => {"name"=>{"type"=>"string"}}}
+      result = format doc, show_command_help?: true
+      result.should =~ /cli example is here/
+    end
+
+    it "displays the API help when the --api flag is true" do
+      doc = {"name"=>"some-help", "help" => {"summary"=>"summary here",
+          "examples"=>{"api"=>"api example is here", "cli"=>"cli example is here"},
+          "full" => "shouldn't show this"},
+          "schema" => {"name"=>{"type"=>"string"}}}
+      result = format doc, show_api_help?: true, show_command_help?: true
+      result.should =~ /api example is here/
+    end
+
+    it "displays the full help if on an older server" do
+      doc = {"name"=>"some-help", "help" => {"full" => "full help is here"},
+             "schema" => {"name"=>{"type"=>"string"}}}
+      result = format doc, show_command_help?: true
+      result.should =~ /full help is here/
+    end
+
+    it "displays the full help if on an older server and api is specified" do
+      doc = {"name"=>"some-help", "help" => {"full" => "full help is here"},
+             "schema" => {"name"=>{"type"=>"string"}}}
+      result = format doc, show_api_help?: true, show_command_help?: true
+      result.should =~ /full help is here/
+    end
+
+    it "skips the 'Examples' section if cli examples are not included" do
+      doc = {"name"=>"some-help", "help" => {"summary"=>"summary here",
+                                             "examples"=>{"api"=>"api example is here"},
+                                             "full" => "shouldn't show this"},
+             "schema" => {"name"=>{"type"=>"string"}}}
+      result = format doc, show_cli_help?: true, show_command_help?: true
+      result.should =~ /summary here/
+      result.should_not =~ /EXAMPLES/
     end
   end
 end

--- a/spec/cli/parse_spec.rb
+++ b/spec/cli/parse_spec.rb
@@ -65,6 +65,14 @@ describe Razor::CLI::Parse do
       it {parse("-k").verify_ssl?.should be false}
     end
 
+    context "with an '-a'" do
+      it {parse("-a").show_api_help?.should be true}
+    end
+
+    context "with an '--api'" do
+      it {parse("--api").show_api_help?.should be true}
+    end
+
     context "with a '--insecure'" do
       it {parse("--insecure").verify_ssl?.should be false}
     end

--- a/spec/fixtures/vcr/Razor_CLI_Navigate/for_command_help/should_provide_API_command_help_for_razor_--api_command_--help_.yml
+++ b/spec/fixtures/vcr/Razor_CLI_Navigate/for_command_help/should_provide_API_command_help_for_razor_--api_command_--help_.yml
@@ -1,0 +1,110 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:8080/api
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json;charset=utf-8
+      Content-Length:
+      - '4975'
+      Date:
+      - Mon, 25 Aug 2014 20:56:24 GMT
+    body:
+      encoding: US-ASCII
+      string: '{"commands":[{"name":"add-policy-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/add-policy-tag","id":"http://localhost:8080/api/commands/add-policy-tag"},{"name":"create-broker","rel":"http://api.puppetlabs.com/razor/v1/commands/create-broker","id":"http://localhost:8080/api/commands/create-broker"},{"name":"create-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/create-policy","id":"http://localhost:8080/api/commands/create-policy"},{"name":"create-repo","rel":"http://api.puppetlabs.com/razor/v1/commands/create-repo","id":"http://localhost:8080/api/commands/create-repo"},{"name":"create-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/create-tag","id":"http://localhost:8080/api/commands/create-tag"},{"name":"create-task","rel":"http://api.puppetlabs.com/razor/v1/commands/create-task","id":"http://localhost:8080/api/commands/create-task"},{"name":"delete-broker","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-broker","id":"http://localhost:8080/api/commands/delete-broker"},{"name":"delete-node","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-node","id":"http://localhost:8080/api/commands/delete-node"},{"name":"delete-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-policy","id":"http://localhost:8080/api/commands/delete-policy"},{"name":"delete-repo","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-repo","id":"http://localhost:8080/api/commands/delete-repo"},{"name":"delete-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-tag","id":"http://localhost:8080/api/commands/delete-tag"},{"name":"disable-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/disable-policy","id":"http://localhost:8080/api/commands/disable-policy"},{"name":"enable-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/enable-policy","id":"http://localhost:8080/api/commands/enable-policy"},{"name":"modify-node-metadata","rel":"http://api.puppetlabs.com/razor/v1/commands/modify-node-metadata","id":"http://localhost:8080/api/commands/modify-node-metadata"},{"name":"modify-policy-max-count","rel":"http://api.puppetlabs.com/razor/v1/commands/modify-policy-max-count","id":"http://localhost:8080/api/commands/modify-policy-max-count"},{"name":"move-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/move-policy","id":"http://localhost:8080/api/commands/move-policy"},{"name":"reboot-node","rel":"http://api.puppetlabs.com/razor/v1/commands/reboot-node","id":"http://localhost:8080/api/commands/reboot-node"},{"name":"register-node","rel":"http://api.puppetlabs.com/razor/v1/commands/register-node","id":"http://localhost:8080/api/commands/register-node"},{"name":"reinstall-node","rel":"http://api.puppetlabs.com/razor/v1/commands/reinstall-node","id":"http://localhost:8080/api/commands/reinstall-node"},{"name":"remove-node-metadata","rel":"http://api.puppetlabs.com/razor/v1/commands/remove-node-metadata","id":"http://localhost:8080/api/commands/remove-node-metadata"},{"name":"remove-policy-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/remove-policy-tag","id":"http://localhost:8080/api/commands/remove-policy-tag"},{"name":"set-node-desired-power-state","rel":"http://api.puppetlabs.com/razor/v1/commands/set-node-desired-power-state","id":"http://localhost:8080/api/commands/set-node-desired-power-state"},{"name":"set-node-hw-info","rel":"http://api.puppetlabs.com/razor/v1/commands/set-node-hw-info","id":"http://localhost:8080/api/commands/set-node-hw-info"},{"name":"set-node-ipmi-credentials","rel":"http://api.puppetlabs.com/razor/v1/commands/set-node-ipmi-credentials","id":"http://localhost:8080/api/commands/set-node-ipmi-credentials"},{"name":"update-node-metadata","rel":"http://api.puppetlabs.com/razor/v1/commands/update-node-metadata","id":"http://localhost:8080/api/commands/update-node-metadata"},{"name":"update-tag-rule","rel":"http://api.puppetlabs.com/razor/v1/commands/update-tag-rule","id":"http://localhost:8080/api/commands/update-tag-rule"}],"collections":[{"name":"brokers","rel":"http://api.puppetlabs.com/razor/v1/collections/brokers","id":"http://localhost:8080/api/collections/brokers"},{"name":"repos","rel":"http://api.puppetlabs.com/razor/v1/collections/repos","id":"http://localhost:8080/api/collections/repos"},{"name":"tags","rel":"http://api.puppetlabs.com/razor/v1/collections/tags","id":"http://localhost:8080/api/collections/tags"},{"name":"policies","rel":"http://api.puppetlabs.com/razor/v1/collections/policies","id":"http://localhost:8080/api/collections/policies"},{"name":"nodes","rel":"http://api.puppetlabs.com/razor/v1/collections/nodes","id":"http://localhost:8080/api/collections/nodes"},{"name":"tasks","rel":"http://api.puppetlabs.com/razor/v1/collections/tasks","id":"http://localhost:8080/api/collections/tasks"},{"name":"commands","rel":"http://api.puppetlabs.com/razor/v1/collections/commands","id":"http://localhost:8080/api/collections/commands"}],"version":{"server":"v0.15.0-32-g1a997ad"}}'
+    http_version:
+  recorded_at: Mon, 25 Aug 2014 20:56:24 GMT
+- request:
+    method: get
+    uri: http://localhost:8080/api/commands/update-tag-rule
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Etag:
+      - '"server-version-v0.15.0-32-g1a997ad"'
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json;charset=utf-8
+      Content-Length:
+      - '3255'
+      Date:
+      - Mon, 25 Aug 2014 20:56:24 GMT
+    body:
+      encoding: US-ASCII
+      string: '{"name":"update-tag-rule","help":{"summary":"Update the matching rule
+        for an existing tag","description":"This will change the rule of the given
+        tag to the new rule. The tag will be\nreevaluated against all nodes and each
+        node''s tag attribute will be updated to\nreflect whether the tag now matches
+        or not, i.e., the tag will be added\nto/removed from each node''s tag as appropriate.\n\nIf
+        the tag is used by any policies, the update will only be performed if the\noptional
+        parameter `force` is set to `true`. Otherwise, it will fail.","schema":"\n#
+        Access Control\n\nThis command''s access control pattern: `commands:update-tag-rule:%{name}`\n\nWords
+        surrounded by `%{...}` are substitutions from the input data: typically\nthe
+        name of the object being modified, or some other critical detail, these\nallow
+        roles to be granted partial access to modify the system.\n\nFor more detail
+        on how the permission strings are structured and work, you can\nsee the [Shiro
+        Permissions documentation][shiro].  That pattern is expanded\nand then a permission
+        check applied to it, before the command is authorized.\n\nThese checks only
+        apply if security is enabled in the Razor configuration\nfile; on this server
+        security is currently disabled.\n\n[shiro]: http://shiro.apache.org/permissions.html\n\n#
+        Attributes\n\n * name\n   - The tag for which to change the rule.\n   - This
+        attribute is required.\n   - It must be of type string.\n   - It must match
+        the name of an existing tag.\n\n * rule\n   - The new rule to apply to the
+        tag.\n   - This attribute is required.\n   - It must be of type array.\n\n
+        * force\n   - By default this command will fail if the tag is in use by an
+        existing\n     policy.  This flag allows you to override that, and force the
+        change to\n     apply despite the tag being in use.\n     \n     This will
+        not change policy binding of nodes, which may lead to some\n     counter-intuitive
+        results such as a node that does *not* match policy\n     tags being bound
+        to the policy.\n   - It must be of type boolean.\n","examples":{"api":"An
+        example of updating a tag rule, and forcing reevaluation:\n\n{\n  \"name\":
+        \"small\",\n  \"rule\": [\"<=\", [\"fact\", \"processorcount\"], \"2\"],\n  \"force\":
+        true\n}","cli":"An example of updating a tag rule, and forcing reevaluation:\n\nrazor
+        update-tag-rule --name small --force         --rule ''[\"<=\", [\"fact\",
+        \"processorcount\"], \"2\"]''"},"full":"# SYNOPSIS\nUpdate the matching rule
+        for an existing tag\n\n# DESCRIPTION\nThis will change the rule of the given
+        tag to the new rule. The tag will be\nreevaluated against all nodes and each
+        node''s tag attribute will be updated to\nreflect whether the tag now matches
+        or not, i.e., the tag will be added\nto/removed from each node''s tag as appropriate.\n\nIf
+        the tag is used by any policies, the update will only be performed if the\noptional
+        parameter `force` is set to `true`. Otherwise, it will fail.\n#<Razor::Validation::HashSchema:0x110c667>\n#
+        EXAMPLES\n\n  An example of updating a tag rule, and forcing reevaluation:\n  \n  {\n    \"name\":
+        \"small\",\n    \"rule\": [\"<=\", [\"fact\", \"processorcount\"], \"2\"],\n    \"force\":
+        true\n  }\n"},"schema":{"name":{"type":"string"},"rule":{"type":"array"},"force":{"type":"boolean"}}}'
+    http_version:
+  recorded_at: Mon, 25 Aug 2014 20:56:24 GMT
+recorded_with: VCR 2.9.2

--- a/spec/fixtures/vcr/Razor_CLI_Navigate/for_command_help/should_provide_API_command_help_for_razor_--api_command_help_.yml
+++ b/spec/fixtures/vcr/Razor_CLI_Navigate/for_command_help/should_provide_API_command_help_for_razor_--api_command_help_.yml
@@ -1,0 +1,110 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:8080/api
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json;charset=utf-8
+      Content-Length:
+      - '4975'
+      Date:
+      - Mon, 25 Aug 2014 20:56:56 GMT
+    body:
+      encoding: US-ASCII
+      string: '{"commands":[{"name":"add-policy-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/add-policy-tag","id":"http://localhost:8080/api/commands/add-policy-tag"},{"name":"create-broker","rel":"http://api.puppetlabs.com/razor/v1/commands/create-broker","id":"http://localhost:8080/api/commands/create-broker"},{"name":"create-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/create-policy","id":"http://localhost:8080/api/commands/create-policy"},{"name":"create-repo","rel":"http://api.puppetlabs.com/razor/v1/commands/create-repo","id":"http://localhost:8080/api/commands/create-repo"},{"name":"create-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/create-tag","id":"http://localhost:8080/api/commands/create-tag"},{"name":"create-task","rel":"http://api.puppetlabs.com/razor/v1/commands/create-task","id":"http://localhost:8080/api/commands/create-task"},{"name":"delete-broker","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-broker","id":"http://localhost:8080/api/commands/delete-broker"},{"name":"delete-node","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-node","id":"http://localhost:8080/api/commands/delete-node"},{"name":"delete-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-policy","id":"http://localhost:8080/api/commands/delete-policy"},{"name":"delete-repo","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-repo","id":"http://localhost:8080/api/commands/delete-repo"},{"name":"delete-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-tag","id":"http://localhost:8080/api/commands/delete-tag"},{"name":"disable-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/disable-policy","id":"http://localhost:8080/api/commands/disable-policy"},{"name":"enable-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/enable-policy","id":"http://localhost:8080/api/commands/enable-policy"},{"name":"modify-node-metadata","rel":"http://api.puppetlabs.com/razor/v1/commands/modify-node-metadata","id":"http://localhost:8080/api/commands/modify-node-metadata"},{"name":"modify-policy-max-count","rel":"http://api.puppetlabs.com/razor/v1/commands/modify-policy-max-count","id":"http://localhost:8080/api/commands/modify-policy-max-count"},{"name":"move-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/move-policy","id":"http://localhost:8080/api/commands/move-policy"},{"name":"reboot-node","rel":"http://api.puppetlabs.com/razor/v1/commands/reboot-node","id":"http://localhost:8080/api/commands/reboot-node"},{"name":"register-node","rel":"http://api.puppetlabs.com/razor/v1/commands/register-node","id":"http://localhost:8080/api/commands/register-node"},{"name":"reinstall-node","rel":"http://api.puppetlabs.com/razor/v1/commands/reinstall-node","id":"http://localhost:8080/api/commands/reinstall-node"},{"name":"remove-node-metadata","rel":"http://api.puppetlabs.com/razor/v1/commands/remove-node-metadata","id":"http://localhost:8080/api/commands/remove-node-metadata"},{"name":"remove-policy-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/remove-policy-tag","id":"http://localhost:8080/api/commands/remove-policy-tag"},{"name":"set-node-desired-power-state","rel":"http://api.puppetlabs.com/razor/v1/commands/set-node-desired-power-state","id":"http://localhost:8080/api/commands/set-node-desired-power-state"},{"name":"set-node-hw-info","rel":"http://api.puppetlabs.com/razor/v1/commands/set-node-hw-info","id":"http://localhost:8080/api/commands/set-node-hw-info"},{"name":"set-node-ipmi-credentials","rel":"http://api.puppetlabs.com/razor/v1/commands/set-node-ipmi-credentials","id":"http://localhost:8080/api/commands/set-node-ipmi-credentials"},{"name":"update-node-metadata","rel":"http://api.puppetlabs.com/razor/v1/commands/update-node-metadata","id":"http://localhost:8080/api/commands/update-node-metadata"},{"name":"update-tag-rule","rel":"http://api.puppetlabs.com/razor/v1/commands/update-tag-rule","id":"http://localhost:8080/api/commands/update-tag-rule"}],"collections":[{"name":"brokers","rel":"http://api.puppetlabs.com/razor/v1/collections/brokers","id":"http://localhost:8080/api/collections/brokers"},{"name":"repos","rel":"http://api.puppetlabs.com/razor/v1/collections/repos","id":"http://localhost:8080/api/collections/repos"},{"name":"tags","rel":"http://api.puppetlabs.com/razor/v1/collections/tags","id":"http://localhost:8080/api/collections/tags"},{"name":"policies","rel":"http://api.puppetlabs.com/razor/v1/collections/policies","id":"http://localhost:8080/api/collections/policies"},{"name":"nodes","rel":"http://api.puppetlabs.com/razor/v1/collections/nodes","id":"http://localhost:8080/api/collections/nodes"},{"name":"tasks","rel":"http://api.puppetlabs.com/razor/v1/collections/tasks","id":"http://localhost:8080/api/collections/tasks"},{"name":"commands","rel":"http://api.puppetlabs.com/razor/v1/collections/commands","id":"http://localhost:8080/api/collections/commands"}],"version":{"server":"v0.15.0-32-g1a997ad"}}'
+    http_version:
+  recorded_at: Mon, 25 Aug 2014 20:56:56 GMT
+- request:
+    method: get
+    uri: http://localhost:8080/api/commands/update-tag-rule
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Etag:
+      - '"server-version-v0.15.0-32-g1a997ad"'
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json;charset=utf-8
+      Content-Length:
+      - '3255'
+      Date:
+      - Mon, 25 Aug 2014 20:56:56 GMT
+    body:
+      encoding: US-ASCII
+      string: '{"name":"update-tag-rule","help":{"summary":"Update the matching rule
+        for an existing tag","description":"This will change the rule of the given
+        tag to the new rule. The tag will be\nreevaluated against all nodes and each
+        node''s tag attribute will be updated to\nreflect whether the tag now matches
+        or not, i.e., the tag will be added\nto/removed from each node''s tag as appropriate.\n\nIf
+        the tag is used by any policies, the update will only be performed if the\noptional
+        parameter `force` is set to `true`. Otherwise, it will fail.","schema":"\n#
+        Access Control\n\nThis command''s access control pattern: `commands:update-tag-rule:%{name}`\n\nWords
+        surrounded by `%{...}` are substitutions from the input data: typically\nthe
+        name of the object being modified, or some other critical detail, these\nallow
+        roles to be granted partial access to modify the system.\n\nFor more detail
+        on how the permission strings are structured and work, you can\nsee the [Shiro
+        Permissions documentation][shiro].  That pattern is expanded\nand then a permission
+        check applied to it, before the command is authorized.\n\nThese checks only
+        apply if security is enabled in the Razor configuration\nfile; on this server
+        security is currently disabled.\n\n[shiro]: http://shiro.apache.org/permissions.html\n\n#
+        Attributes\n\n * name\n   - The tag for which to change the rule.\n   - This
+        attribute is required.\n   - It must be of type string.\n   - It must match
+        the name of an existing tag.\n\n * rule\n   - The new rule to apply to the
+        tag.\n   - This attribute is required.\n   - It must be of type array.\n\n
+        * force\n   - By default this command will fail if the tag is in use by an
+        existing\n     policy.  This flag allows you to override that, and force the
+        change to\n     apply despite the tag being in use.\n     \n     This will
+        not change policy binding of nodes, which may lead to some\n     counter-intuitive
+        results such as a node that does *not* match policy\n     tags being bound
+        to the policy.\n   - It must be of type boolean.\n","examples":{"api":"An
+        example of updating a tag rule, and forcing reevaluation:\n\n{\n  \"name\":
+        \"small\",\n  \"rule\": [\"<=\", [\"fact\", \"processorcount\"], \"2\"],\n  \"force\":
+        true\n}","cli":"An example of updating a tag rule, and forcing reevaluation:\n\nrazor
+        update-tag-rule --name small --force         --rule ''[\"<=\", [\"fact\",
+        \"processorcount\"], \"2\"]''"},"full":"# SYNOPSIS\nUpdate the matching rule
+        for an existing tag\n\n# DESCRIPTION\nThis will change the rule of the given
+        tag to the new rule. The tag will be\nreevaluated against all nodes and each
+        node''s tag attribute will be updated to\nreflect whether the tag now matches
+        or not, i.e., the tag will be added\nto/removed from each node''s tag as appropriate.\n\nIf
+        the tag is used by any policies, the update will only be performed if the\noptional
+        parameter `force` is set to `true`. Otherwise, it will fail.\n#<Razor::Validation::HashSchema:0x110c667>\n#
+        EXAMPLES\n\n  An example of updating a tag rule, and forcing reevaluation:\n  \n  {\n    \"name\":
+        \"small\",\n    \"rule\": [\"<=\", [\"fact\", \"processorcount\"], \"2\"],\n    \"force\":
+        true\n  }\n"},"schema":{"name":{"type":"string"},"rule":{"type":"array"},"force":{"type":"boolean"}}}'
+    http_version:
+  recorded_at: Mon, 25 Aug 2014 20:56:56 GMT
+recorded_with: VCR 2.9.2

--- a/spec/fixtures/vcr/Razor_CLI_Navigate/for_command_help/should_provide_API_command_help_for_razor_--api_help_command_.yml
+++ b/spec/fixtures/vcr/Razor_CLI_Navigate/for_command_help/should_provide_API_command_help_for_razor_--api_help_command_.yml
@@ -1,0 +1,110 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:8080/api
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json;charset=utf-8
+      Content-Length:
+      - '4975'
+      Date:
+      - Mon, 25 Aug 2014 20:56:50 GMT
+    body:
+      encoding: US-ASCII
+      string: '{"commands":[{"name":"add-policy-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/add-policy-tag","id":"http://localhost:8080/api/commands/add-policy-tag"},{"name":"create-broker","rel":"http://api.puppetlabs.com/razor/v1/commands/create-broker","id":"http://localhost:8080/api/commands/create-broker"},{"name":"create-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/create-policy","id":"http://localhost:8080/api/commands/create-policy"},{"name":"create-repo","rel":"http://api.puppetlabs.com/razor/v1/commands/create-repo","id":"http://localhost:8080/api/commands/create-repo"},{"name":"create-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/create-tag","id":"http://localhost:8080/api/commands/create-tag"},{"name":"create-task","rel":"http://api.puppetlabs.com/razor/v1/commands/create-task","id":"http://localhost:8080/api/commands/create-task"},{"name":"delete-broker","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-broker","id":"http://localhost:8080/api/commands/delete-broker"},{"name":"delete-node","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-node","id":"http://localhost:8080/api/commands/delete-node"},{"name":"delete-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-policy","id":"http://localhost:8080/api/commands/delete-policy"},{"name":"delete-repo","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-repo","id":"http://localhost:8080/api/commands/delete-repo"},{"name":"delete-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-tag","id":"http://localhost:8080/api/commands/delete-tag"},{"name":"disable-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/disable-policy","id":"http://localhost:8080/api/commands/disable-policy"},{"name":"enable-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/enable-policy","id":"http://localhost:8080/api/commands/enable-policy"},{"name":"modify-node-metadata","rel":"http://api.puppetlabs.com/razor/v1/commands/modify-node-metadata","id":"http://localhost:8080/api/commands/modify-node-metadata"},{"name":"modify-policy-max-count","rel":"http://api.puppetlabs.com/razor/v1/commands/modify-policy-max-count","id":"http://localhost:8080/api/commands/modify-policy-max-count"},{"name":"move-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/move-policy","id":"http://localhost:8080/api/commands/move-policy"},{"name":"reboot-node","rel":"http://api.puppetlabs.com/razor/v1/commands/reboot-node","id":"http://localhost:8080/api/commands/reboot-node"},{"name":"register-node","rel":"http://api.puppetlabs.com/razor/v1/commands/register-node","id":"http://localhost:8080/api/commands/register-node"},{"name":"reinstall-node","rel":"http://api.puppetlabs.com/razor/v1/commands/reinstall-node","id":"http://localhost:8080/api/commands/reinstall-node"},{"name":"remove-node-metadata","rel":"http://api.puppetlabs.com/razor/v1/commands/remove-node-metadata","id":"http://localhost:8080/api/commands/remove-node-metadata"},{"name":"remove-policy-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/remove-policy-tag","id":"http://localhost:8080/api/commands/remove-policy-tag"},{"name":"set-node-desired-power-state","rel":"http://api.puppetlabs.com/razor/v1/commands/set-node-desired-power-state","id":"http://localhost:8080/api/commands/set-node-desired-power-state"},{"name":"set-node-hw-info","rel":"http://api.puppetlabs.com/razor/v1/commands/set-node-hw-info","id":"http://localhost:8080/api/commands/set-node-hw-info"},{"name":"set-node-ipmi-credentials","rel":"http://api.puppetlabs.com/razor/v1/commands/set-node-ipmi-credentials","id":"http://localhost:8080/api/commands/set-node-ipmi-credentials"},{"name":"update-node-metadata","rel":"http://api.puppetlabs.com/razor/v1/commands/update-node-metadata","id":"http://localhost:8080/api/commands/update-node-metadata"},{"name":"update-tag-rule","rel":"http://api.puppetlabs.com/razor/v1/commands/update-tag-rule","id":"http://localhost:8080/api/commands/update-tag-rule"}],"collections":[{"name":"brokers","rel":"http://api.puppetlabs.com/razor/v1/collections/brokers","id":"http://localhost:8080/api/collections/brokers"},{"name":"repos","rel":"http://api.puppetlabs.com/razor/v1/collections/repos","id":"http://localhost:8080/api/collections/repos"},{"name":"tags","rel":"http://api.puppetlabs.com/razor/v1/collections/tags","id":"http://localhost:8080/api/collections/tags"},{"name":"policies","rel":"http://api.puppetlabs.com/razor/v1/collections/policies","id":"http://localhost:8080/api/collections/policies"},{"name":"nodes","rel":"http://api.puppetlabs.com/razor/v1/collections/nodes","id":"http://localhost:8080/api/collections/nodes"},{"name":"tasks","rel":"http://api.puppetlabs.com/razor/v1/collections/tasks","id":"http://localhost:8080/api/collections/tasks"},{"name":"commands","rel":"http://api.puppetlabs.com/razor/v1/collections/commands","id":"http://localhost:8080/api/collections/commands"}],"version":{"server":"v0.15.0-32-g1a997ad"}}'
+    http_version:
+  recorded_at: Mon, 25 Aug 2014 20:56:50 GMT
+- request:
+    method: get
+    uri: http://localhost:8080/api/commands/update-tag-rule
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Etag:
+      - '"server-version-v0.15.0-32-g1a997ad"'
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json;charset=utf-8
+      Content-Length:
+      - '3255'
+      Date:
+      - Mon, 25 Aug 2014 20:56:50 GMT
+    body:
+      encoding: US-ASCII
+      string: '{"name":"update-tag-rule","help":{"summary":"Update the matching rule
+        for an existing tag","description":"This will change the rule of the given
+        tag to the new rule. The tag will be\nreevaluated against all nodes and each
+        node''s tag attribute will be updated to\nreflect whether the tag now matches
+        or not, i.e., the tag will be added\nto/removed from each node''s tag as appropriate.\n\nIf
+        the tag is used by any policies, the update will only be performed if the\noptional
+        parameter `force` is set to `true`. Otherwise, it will fail.","schema":"\n#
+        Access Control\n\nThis command''s access control pattern: `commands:update-tag-rule:%{name}`\n\nWords
+        surrounded by `%{...}` are substitutions from the input data: typically\nthe
+        name of the object being modified, or some other critical detail, these\nallow
+        roles to be granted partial access to modify the system.\n\nFor more detail
+        on how the permission strings are structured and work, you can\nsee the [Shiro
+        Permissions documentation][shiro].  That pattern is expanded\nand then a permission
+        check applied to it, before the command is authorized.\n\nThese checks only
+        apply if security is enabled in the Razor configuration\nfile; on this server
+        security is currently disabled.\n\n[shiro]: http://shiro.apache.org/permissions.html\n\n#
+        Attributes\n\n * name\n   - The tag for which to change the rule.\n   - This
+        attribute is required.\n   - It must be of type string.\n   - It must match
+        the name of an existing tag.\n\n * rule\n   - The new rule to apply to the
+        tag.\n   - This attribute is required.\n   - It must be of type array.\n\n
+        * force\n   - By default this command will fail if the tag is in use by an
+        existing\n     policy.  This flag allows you to override that, and force the
+        change to\n     apply despite the tag being in use.\n     \n     This will
+        not change policy binding of nodes, which may lead to some\n     counter-intuitive
+        results such as a node that does *not* match policy\n     tags being bound
+        to the policy.\n   - It must be of type boolean.\n","examples":{"api":"An
+        example of updating a tag rule, and forcing reevaluation:\n\n{\n  \"name\":
+        \"small\",\n  \"rule\": [\"<=\", [\"fact\", \"processorcount\"], \"2\"],\n  \"force\":
+        true\n}","cli":"An example of updating a tag rule, and forcing reevaluation:\n\nrazor
+        update-tag-rule --name small --force         --rule ''[\"<=\", [\"fact\",
+        \"processorcount\"], \"2\"]''"},"full":"# SYNOPSIS\nUpdate the matching rule
+        for an existing tag\n\n# DESCRIPTION\nThis will change the rule of the given
+        tag to the new rule. The tag will be\nreevaluated against all nodes and each
+        node''s tag attribute will be updated to\nreflect whether the tag now matches
+        or not, i.e., the tag will be added\nto/removed from each node''s tag as appropriate.\n\nIf
+        the tag is used by any policies, the update will only be performed if the\noptional
+        parameter `force` is set to `true`. Otherwise, it will fail.\n#<Razor::Validation::HashSchema:0x110c667>\n#
+        EXAMPLES\n\n  An example of updating a tag rule, and forcing reevaluation:\n  \n  {\n    \"name\":
+        \"small\",\n    \"rule\": [\"<=\", [\"fact\", \"processorcount\"], \"2\"],\n    \"force\":
+        true\n  }\n"},"schema":{"name":{"type":"string"},"rule":{"type":"array"},"force":{"type":"boolean"}}}'
+    http_version:
+  recorded_at: Mon, 25 Aug 2014 20:56:50 GMT
+recorded_with: VCR 2.9.2

--- a/spec/fixtures/vcr/Razor_CLI_Navigate/for_command_help/should_provide_API_command_help_for_razor_--help_--api_command_.yml
+++ b/spec/fixtures/vcr/Razor_CLI_Navigate/for_command_help/should_provide_API_command_help_for_razor_--help_--api_command_.yml
@@ -1,0 +1,110 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:8080/api
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json;charset=utf-8
+      Content-Length:
+      - '4975'
+      Date:
+      - Mon, 25 Aug 2014 20:56:37 GMT
+    body:
+      encoding: US-ASCII
+      string: '{"commands":[{"name":"add-policy-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/add-policy-tag","id":"http://localhost:8080/api/commands/add-policy-tag"},{"name":"create-broker","rel":"http://api.puppetlabs.com/razor/v1/commands/create-broker","id":"http://localhost:8080/api/commands/create-broker"},{"name":"create-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/create-policy","id":"http://localhost:8080/api/commands/create-policy"},{"name":"create-repo","rel":"http://api.puppetlabs.com/razor/v1/commands/create-repo","id":"http://localhost:8080/api/commands/create-repo"},{"name":"create-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/create-tag","id":"http://localhost:8080/api/commands/create-tag"},{"name":"create-task","rel":"http://api.puppetlabs.com/razor/v1/commands/create-task","id":"http://localhost:8080/api/commands/create-task"},{"name":"delete-broker","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-broker","id":"http://localhost:8080/api/commands/delete-broker"},{"name":"delete-node","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-node","id":"http://localhost:8080/api/commands/delete-node"},{"name":"delete-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-policy","id":"http://localhost:8080/api/commands/delete-policy"},{"name":"delete-repo","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-repo","id":"http://localhost:8080/api/commands/delete-repo"},{"name":"delete-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-tag","id":"http://localhost:8080/api/commands/delete-tag"},{"name":"disable-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/disable-policy","id":"http://localhost:8080/api/commands/disable-policy"},{"name":"enable-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/enable-policy","id":"http://localhost:8080/api/commands/enable-policy"},{"name":"modify-node-metadata","rel":"http://api.puppetlabs.com/razor/v1/commands/modify-node-metadata","id":"http://localhost:8080/api/commands/modify-node-metadata"},{"name":"modify-policy-max-count","rel":"http://api.puppetlabs.com/razor/v1/commands/modify-policy-max-count","id":"http://localhost:8080/api/commands/modify-policy-max-count"},{"name":"move-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/move-policy","id":"http://localhost:8080/api/commands/move-policy"},{"name":"reboot-node","rel":"http://api.puppetlabs.com/razor/v1/commands/reboot-node","id":"http://localhost:8080/api/commands/reboot-node"},{"name":"register-node","rel":"http://api.puppetlabs.com/razor/v1/commands/register-node","id":"http://localhost:8080/api/commands/register-node"},{"name":"reinstall-node","rel":"http://api.puppetlabs.com/razor/v1/commands/reinstall-node","id":"http://localhost:8080/api/commands/reinstall-node"},{"name":"remove-node-metadata","rel":"http://api.puppetlabs.com/razor/v1/commands/remove-node-metadata","id":"http://localhost:8080/api/commands/remove-node-metadata"},{"name":"remove-policy-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/remove-policy-tag","id":"http://localhost:8080/api/commands/remove-policy-tag"},{"name":"set-node-desired-power-state","rel":"http://api.puppetlabs.com/razor/v1/commands/set-node-desired-power-state","id":"http://localhost:8080/api/commands/set-node-desired-power-state"},{"name":"set-node-hw-info","rel":"http://api.puppetlabs.com/razor/v1/commands/set-node-hw-info","id":"http://localhost:8080/api/commands/set-node-hw-info"},{"name":"set-node-ipmi-credentials","rel":"http://api.puppetlabs.com/razor/v1/commands/set-node-ipmi-credentials","id":"http://localhost:8080/api/commands/set-node-ipmi-credentials"},{"name":"update-node-metadata","rel":"http://api.puppetlabs.com/razor/v1/commands/update-node-metadata","id":"http://localhost:8080/api/commands/update-node-metadata"},{"name":"update-tag-rule","rel":"http://api.puppetlabs.com/razor/v1/commands/update-tag-rule","id":"http://localhost:8080/api/commands/update-tag-rule"}],"collections":[{"name":"brokers","rel":"http://api.puppetlabs.com/razor/v1/collections/brokers","id":"http://localhost:8080/api/collections/brokers"},{"name":"repos","rel":"http://api.puppetlabs.com/razor/v1/collections/repos","id":"http://localhost:8080/api/collections/repos"},{"name":"tags","rel":"http://api.puppetlabs.com/razor/v1/collections/tags","id":"http://localhost:8080/api/collections/tags"},{"name":"policies","rel":"http://api.puppetlabs.com/razor/v1/collections/policies","id":"http://localhost:8080/api/collections/policies"},{"name":"nodes","rel":"http://api.puppetlabs.com/razor/v1/collections/nodes","id":"http://localhost:8080/api/collections/nodes"},{"name":"tasks","rel":"http://api.puppetlabs.com/razor/v1/collections/tasks","id":"http://localhost:8080/api/collections/tasks"},{"name":"commands","rel":"http://api.puppetlabs.com/razor/v1/collections/commands","id":"http://localhost:8080/api/collections/commands"}],"version":{"server":"v0.15.0-32-g1a997ad"}}'
+    http_version:
+  recorded_at: Mon, 25 Aug 2014 20:56:37 GMT
+- request:
+    method: get
+    uri: http://localhost:8080/api/commands/update-tag-rule
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Etag:
+      - '"server-version-v0.15.0-32-g1a997ad"'
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json;charset=utf-8
+      Content-Length:
+      - '3255'
+      Date:
+      - Mon, 25 Aug 2014 20:56:37 GMT
+    body:
+      encoding: US-ASCII
+      string: '{"name":"update-tag-rule","help":{"summary":"Update the matching rule
+        for an existing tag","description":"This will change the rule of the given
+        tag to the new rule. The tag will be\nreevaluated against all nodes and each
+        node''s tag attribute will be updated to\nreflect whether the tag now matches
+        or not, i.e., the tag will be added\nto/removed from each node''s tag as appropriate.\n\nIf
+        the tag is used by any policies, the update will only be performed if the\noptional
+        parameter `force` is set to `true`. Otherwise, it will fail.","schema":"\n#
+        Access Control\n\nThis command''s access control pattern: `commands:update-tag-rule:%{name}`\n\nWords
+        surrounded by `%{...}` are substitutions from the input data: typically\nthe
+        name of the object being modified, or some other critical detail, these\nallow
+        roles to be granted partial access to modify the system.\n\nFor more detail
+        on how the permission strings are structured and work, you can\nsee the [Shiro
+        Permissions documentation][shiro].  That pattern is expanded\nand then a permission
+        check applied to it, before the command is authorized.\n\nThese checks only
+        apply if security is enabled in the Razor configuration\nfile; on this server
+        security is currently disabled.\n\n[shiro]: http://shiro.apache.org/permissions.html\n\n#
+        Attributes\n\n * name\n   - The tag for which to change the rule.\n   - This
+        attribute is required.\n   - It must be of type string.\n   - It must match
+        the name of an existing tag.\n\n * rule\n   - The new rule to apply to the
+        tag.\n   - This attribute is required.\n   - It must be of type array.\n\n
+        * force\n   - By default this command will fail if the tag is in use by an
+        existing\n     policy.  This flag allows you to override that, and force the
+        change to\n     apply despite the tag being in use.\n     \n     This will
+        not change policy binding of nodes, which may lead to some\n     counter-intuitive
+        results such as a node that does *not* match policy\n     tags being bound
+        to the policy.\n   - It must be of type boolean.\n","examples":{"api":"An
+        example of updating a tag rule, and forcing reevaluation:\n\n{\n  \"name\":
+        \"small\",\n  \"rule\": [\"<=\", [\"fact\", \"processorcount\"], \"2\"],\n  \"force\":
+        true\n}","cli":"An example of updating a tag rule, and forcing reevaluation:\n\nrazor
+        update-tag-rule --name small --force         --rule ''[\"<=\", [\"fact\",
+        \"processorcount\"], \"2\"]''"},"full":"# SYNOPSIS\nUpdate the matching rule
+        for an existing tag\n\n# DESCRIPTION\nThis will change the rule of the given
+        tag to the new rule. The tag will be\nreevaluated against all nodes and each
+        node''s tag attribute will be updated to\nreflect whether the tag now matches
+        or not, i.e., the tag will be added\nto/removed from each node''s tag as appropriate.\n\nIf
+        the tag is used by any policies, the update will only be performed if the\noptional
+        parameter `force` is set to `true`. Otherwise, it will fail.\n#<Razor::Validation::HashSchema:0x110c667>\n#
+        EXAMPLES\n\n  An example of updating a tag rule, and forcing reevaluation:\n  \n  {\n    \"name\":
+        \"small\",\n    \"rule\": [\"<=\", [\"fact\", \"processorcount\"], \"2\"],\n    \"force\":
+        true\n  }\n"},"schema":{"name":{"type":"string"},"rule":{"type":"array"},"force":{"type":"boolean"}}}'
+    http_version:
+  recorded_at: Mon, 25 Aug 2014 20:56:37 GMT
+recorded_with: VCR 2.9.2

--- a/spec/fixtures/vcr/Razor_CLI_Navigate/for_command_help/should_provide_API_command_help_for_razor_-a_-h_command_.yml
+++ b/spec/fixtures/vcr/Razor_CLI_Navigate/for_command_help/should_provide_API_command_help_for_razor_-a_-h_command_.yml
@@ -1,0 +1,110 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:8080/api
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json;charset=utf-8
+      Content-Length:
+      - '4975'
+      Date:
+      - Mon, 25 Aug 2014 20:56:43 GMT
+    body:
+      encoding: US-ASCII
+      string: '{"commands":[{"name":"add-policy-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/add-policy-tag","id":"http://localhost:8080/api/commands/add-policy-tag"},{"name":"create-broker","rel":"http://api.puppetlabs.com/razor/v1/commands/create-broker","id":"http://localhost:8080/api/commands/create-broker"},{"name":"create-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/create-policy","id":"http://localhost:8080/api/commands/create-policy"},{"name":"create-repo","rel":"http://api.puppetlabs.com/razor/v1/commands/create-repo","id":"http://localhost:8080/api/commands/create-repo"},{"name":"create-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/create-tag","id":"http://localhost:8080/api/commands/create-tag"},{"name":"create-task","rel":"http://api.puppetlabs.com/razor/v1/commands/create-task","id":"http://localhost:8080/api/commands/create-task"},{"name":"delete-broker","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-broker","id":"http://localhost:8080/api/commands/delete-broker"},{"name":"delete-node","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-node","id":"http://localhost:8080/api/commands/delete-node"},{"name":"delete-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-policy","id":"http://localhost:8080/api/commands/delete-policy"},{"name":"delete-repo","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-repo","id":"http://localhost:8080/api/commands/delete-repo"},{"name":"delete-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-tag","id":"http://localhost:8080/api/commands/delete-tag"},{"name":"disable-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/disable-policy","id":"http://localhost:8080/api/commands/disable-policy"},{"name":"enable-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/enable-policy","id":"http://localhost:8080/api/commands/enable-policy"},{"name":"modify-node-metadata","rel":"http://api.puppetlabs.com/razor/v1/commands/modify-node-metadata","id":"http://localhost:8080/api/commands/modify-node-metadata"},{"name":"modify-policy-max-count","rel":"http://api.puppetlabs.com/razor/v1/commands/modify-policy-max-count","id":"http://localhost:8080/api/commands/modify-policy-max-count"},{"name":"move-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/move-policy","id":"http://localhost:8080/api/commands/move-policy"},{"name":"reboot-node","rel":"http://api.puppetlabs.com/razor/v1/commands/reboot-node","id":"http://localhost:8080/api/commands/reboot-node"},{"name":"register-node","rel":"http://api.puppetlabs.com/razor/v1/commands/register-node","id":"http://localhost:8080/api/commands/register-node"},{"name":"reinstall-node","rel":"http://api.puppetlabs.com/razor/v1/commands/reinstall-node","id":"http://localhost:8080/api/commands/reinstall-node"},{"name":"remove-node-metadata","rel":"http://api.puppetlabs.com/razor/v1/commands/remove-node-metadata","id":"http://localhost:8080/api/commands/remove-node-metadata"},{"name":"remove-policy-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/remove-policy-tag","id":"http://localhost:8080/api/commands/remove-policy-tag"},{"name":"set-node-desired-power-state","rel":"http://api.puppetlabs.com/razor/v1/commands/set-node-desired-power-state","id":"http://localhost:8080/api/commands/set-node-desired-power-state"},{"name":"set-node-hw-info","rel":"http://api.puppetlabs.com/razor/v1/commands/set-node-hw-info","id":"http://localhost:8080/api/commands/set-node-hw-info"},{"name":"set-node-ipmi-credentials","rel":"http://api.puppetlabs.com/razor/v1/commands/set-node-ipmi-credentials","id":"http://localhost:8080/api/commands/set-node-ipmi-credentials"},{"name":"update-node-metadata","rel":"http://api.puppetlabs.com/razor/v1/commands/update-node-metadata","id":"http://localhost:8080/api/commands/update-node-metadata"},{"name":"update-tag-rule","rel":"http://api.puppetlabs.com/razor/v1/commands/update-tag-rule","id":"http://localhost:8080/api/commands/update-tag-rule"}],"collections":[{"name":"brokers","rel":"http://api.puppetlabs.com/razor/v1/collections/brokers","id":"http://localhost:8080/api/collections/brokers"},{"name":"repos","rel":"http://api.puppetlabs.com/razor/v1/collections/repos","id":"http://localhost:8080/api/collections/repos"},{"name":"tags","rel":"http://api.puppetlabs.com/razor/v1/collections/tags","id":"http://localhost:8080/api/collections/tags"},{"name":"policies","rel":"http://api.puppetlabs.com/razor/v1/collections/policies","id":"http://localhost:8080/api/collections/policies"},{"name":"nodes","rel":"http://api.puppetlabs.com/razor/v1/collections/nodes","id":"http://localhost:8080/api/collections/nodes"},{"name":"tasks","rel":"http://api.puppetlabs.com/razor/v1/collections/tasks","id":"http://localhost:8080/api/collections/tasks"},{"name":"commands","rel":"http://api.puppetlabs.com/razor/v1/collections/commands","id":"http://localhost:8080/api/collections/commands"}],"version":{"server":"v0.15.0-32-g1a997ad"}}'
+    http_version:
+  recorded_at: Mon, 25 Aug 2014 20:56:43 GMT
+- request:
+    method: get
+    uri: http://localhost:8080/api/commands/update-tag-rule
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Etag:
+      - '"server-version-v0.15.0-32-g1a997ad"'
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json;charset=utf-8
+      Content-Length:
+      - '3255'
+      Date:
+      - Mon, 25 Aug 2014 20:56:43 GMT
+    body:
+      encoding: US-ASCII
+      string: '{"name":"update-tag-rule","help":{"summary":"Update the matching rule
+        for an existing tag","description":"This will change the rule of the given
+        tag to the new rule. The tag will be\nreevaluated against all nodes and each
+        node''s tag attribute will be updated to\nreflect whether the tag now matches
+        or not, i.e., the tag will be added\nto/removed from each node''s tag as appropriate.\n\nIf
+        the tag is used by any policies, the update will only be performed if the\noptional
+        parameter `force` is set to `true`. Otherwise, it will fail.","schema":"\n#
+        Access Control\n\nThis command''s access control pattern: `commands:update-tag-rule:%{name}`\n\nWords
+        surrounded by `%{...}` are substitutions from the input data: typically\nthe
+        name of the object being modified, or some other critical detail, these\nallow
+        roles to be granted partial access to modify the system.\n\nFor more detail
+        on how the permission strings are structured and work, you can\nsee the [Shiro
+        Permissions documentation][shiro].  That pattern is expanded\nand then a permission
+        check applied to it, before the command is authorized.\n\nThese checks only
+        apply if security is enabled in the Razor configuration\nfile; on this server
+        security is currently disabled.\n\n[shiro]: http://shiro.apache.org/permissions.html\n\n#
+        Attributes\n\n * name\n   - The tag for which to change the rule.\n   - This
+        attribute is required.\n   - It must be of type string.\n   - It must match
+        the name of an existing tag.\n\n * rule\n   - The new rule to apply to the
+        tag.\n   - This attribute is required.\n   - It must be of type array.\n\n
+        * force\n   - By default this command will fail if the tag is in use by an
+        existing\n     policy.  This flag allows you to override that, and force the
+        change to\n     apply despite the tag being in use.\n     \n     This will
+        not change policy binding of nodes, which may lead to some\n     counter-intuitive
+        results such as a node that does *not* match policy\n     tags being bound
+        to the policy.\n   - It must be of type boolean.\n","examples":{"api":"An
+        example of updating a tag rule, and forcing reevaluation:\n\n{\n  \"name\":
+        \"small\",\n  \"rule\": [\"<=\", [\"fact\", \"processorcount\"], \"2\"],\n  \"force\":
+        true\n}","cli":"An example of updating a tag rule, and forcing reevaluation:\n\nrazor
+        update-tag-rule --name small --force         --rule ''[\"<=\", [\"fact\",
+        \"processorcount\"], \"2\"]''"},"full":"# SYNOPSIS\nUpdate the matching rule
+        for an existing tag\n\n# DESCRIPTION\nThis will change the rule of the given
+        tag to the new rule. The tag will be\nreevaluated against all nodes and each
+        node''s tag attribute will be updated to\nreflect whether the tag now matches
+        or not, i.e., the tag will be added\nto/removed from each node''s tag as appropriate.\n\nIf
+        the tag is used by any policies, the update will only be performed if the\noptional
+        parameter `force` is set to `true`. Otherwise, it will fail.\n#<Razor::Validation::HashSchema:0x110c667>\n#
+        EXAMPLES\n\n  An example of updating a tag rule, and forcing reevaluation:\n  \n  {\n    \"name\":
+        \"small\",\n    \"rule\": [\"<=\", [\"fact\", \"processorcount\"], \"2\"],\n    \"force\":
+        true\n  }\n"},"schema":{"name":{"type":"string"},"rule":{"type":"array"},"force":{"type":"boolean"}}}'
+    http_version:
+  recorded_at: Mon, 25 Aug 2014 20:56:43 GMT
+recorded_with: VCR 2.9.2

--- a/spec/fixtures/vcr/Razor_CLI_Navigate/for_command_help/should_provide_API_command_help_for_razor_-a_command_-h_.yml
+++ b/spec/fixtures/vcr/Razor_CLI_Navigate/for_command_help/should_provide_API_command_help_for_razor_-a_command_-h_.yml
@@ -1,0 +1,110 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:8080/api
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json;charset=utf-8
+      Content-Length:
+      - '4975'
+      Date:
+      - Mon, 25 Aug 2014 20:56:31 GMT
+    body:
+      encoding: US-ASCII
+      string: '{"commands":[{"name":"add-policy-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/add-policy-tag","id":"http://localhost:8080/api/commands/add-policy-tag"},{"name":"create-broker","rel":"http://api.puppetlabs.com/razor/v1/commands/create-broker","id":"http://localhost:8080/api/commands/create-broker"},{"name":"create-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/create-policy","id":"http://localhost:8080/api/commands/create-policy"},{"name":"create-repo","rel":"http://api.puppetlabs.com/razor/v1/commands/create-repo","id":"http://localhost:8080/api/commands/create-repo"},{"name":"create-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/create-tag","id":"http://localhost:8080/api/commands/create-tag"},{"name":"create-task","rel":"http://api.puppetlabs.com/razor/v1/commands/create-task","id":"http://localhost:8080/api/commands/create-task"},{"name":"delete-broker","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-broker","id":"http://localhost:8080/api/commands/delete-broker"},{"name":"delete-node","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-node","id":"http://localhost:8080/api/commands/delete-node"},{"name":"delete-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-policy","id":"http://localhost:8080/api/commands/delete-policy"},{"name":"delete-repo","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-repo","id":"http://localhost:8080/api/commands/delete-repo"},{"name":"delete-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-tag","id":"http://localhost:8080/api/commands/delete-tag"},{"name":"disable-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/disable-policy","id":"http://localhost:8080/api/commands/disable-policy"},{"name":"enable-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/enable-policy","id":"http://localhost:8080/api/commands/enable-policy"},{"name":"modify-node-metadata","rel":"http://api.puppetlabs.com/razor/v1/commands/modify-node-metadata","id":"http://localhost:8080/api/commands/modify-node-metadata"},{"name":"modify-policy-max-count","rel":"http://api.puppetlabs.com/razor/v1/commands/modify-policy-max-count","id":"http://localhost:8080/api/commands/modify-policy-max-count"},{"name":"move-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/move-policy","id":"http://localhost:8080/api/commands/move-policy"},{"name":"reboot-node","rel":"http://api.puppetlabs.com/razor/v1/commands/reboot-node","id":"http://localhost:8080/api/commands/reboot-node"},{"name":"register-node","rel":"http://api.puppetlabs.com/razor/v1/commands/register-node","id":"http://localhost:8080/api/commands/register-node"},{"name":"reinstall-node","rel":"http://api.puppetlabs.com/razor/v1/commands/reinstall-node","id":"http://localhost:8080/api/commands/reinstall-node"},{"name":"remove-node-metadata","rel":"http://api.puppetlabs.com/razor/v1/commands/remove-node-metadata","id":"http://localhost:8080/api/commands/remove-node-metadata"},{"name":"remove-policy-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/remove-policy-tag","id":"http://localhost:8080/api/commands/remove-policy-tag"},{"name":"set-node-desired-power-state","rel":"http://api.puppetlabs.com/razor/v1/commands/set-node-desired-power-state","id":"http://localhost:8080/api/commands/set-node-desired-power-state"},{"name":"set-node-hw-info","rel":"http://api.puppetlabs.com/razor/v1/commands/set-node-hw-info","id":"http://localhost:8080/api/commands/set-node-hw-info"},{"name":"set-node-ipmi-credentials","rel":"http://api.puppetlabs.com/razor/v1/commands/set-node-ipmi-credentials","id":"http://localhost:8080/api/commands/set-node-ipmi-credentials"},{"name":"update-node-metadata","rel":"http://api.puppetlabs.com/razor/v1/commands/update-node-metadata","id":"http://localhost:8080/api/commands/update-node-metadata"},{"name":"update-tag-rule","rel":"http://api.puppetlabs.com/razor/v1/commands/update-tag-rule","id":"http://localhost:8080/api/commands/update-tag-rule"}],"collections":[{"name":"brokers","rel":"http://api.puppetlabs.com/razor/v1/collections/brokers","id":"http://localhost:8080/api/collections/brokers"},{"name":"repos","rel":"http://api.puppetlabs.com/razor/v1/collections/repos","id":"http://localhost:8080/api/collections/repos"},{"name":"tags","rel":"http://api.puppetlabs.com/razor/v1/collections/tags","id":"http://localhost:8080/api/collections/tags"},{"name":"policies","rel":"http://api.puppetlabs.com/razor/v1/collections/policies","id":"http://localhost:8080/api/collections/policies"},{"name":"nodes","rel":"http://api.puppetlabs.com/razor/v1/collections/nodes","id":"http://localhost:8080/api/collections/nodes"},{"name":"tasks","rel":"http://api.puppetlabs.com/razor/v1/collections/tasks","id":"http://localhost:8080/api/collections/tasks"},{"name":"commands","rel":"http://api.puppetlabs.com/razor/v1/collections/commands","id":"http://localhost:8080/api/collections/commands"}],"version":{"server":"v0.15.0-32-g1a997ad"}}'
+    http_version:
+  recorded_at: Mon, 25 Aug 2014 20:56:31 GMT
+- request:
+    method: get
+    uri: http://localhost:8080/api/commands/update-tag-rule
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Etag:
+      - '"server-version-v0.15.0-32-g1a997ad"'
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json;charset=utf-8
+      Content-Length:
+      - '3255'
+      Date:
+      - Mon, 25 Aug 2014 20:56:31 GMT
+    body:
+      encoding: US-ASCII
+      string: '{"name":"update-tag-rule","help":{"summary":"Update the matching rule
+        for an existing tag","description":"This will change the rule of the given
+        tag to the new rule. The tag will be\nreevaluated against all nodes and each
+        node''s tag attribute will be updated to\nreflect whether the tag now matches
+        or not, i.e., the tag will be added\nto/removed from each node''s tag as appropriate.\n\nIf
+        the tag is used by any policies, the update will only be performed if the\noptional
+        parameter `force` is set to `true`. Otherwise, it will fail.","schema":"\n#
+        Access Control\n\nThis command''s access control pattern: `commands:update-tag-rule:%{name}`\n\nWords
+        surrounded by `%{...}` are substitutions from the input data: typically\nthe
+        name of the object being modified, or some other critical detail, these\nallow
+        roles to be granted partial access to modify the system.\n\nFor more detail
+        on how the permission strings are structured and work, you can\nsee the [Shiro
+        Permissions documentation][shiro].  That pattern is expanded\nand then a permission
+        check applied to it, before the command is authorized.\n\nThese checks only
+        apply if security is enabled in the Razor configuration\nfile; on this server
+        security is currently disabled.\n\n[shiro]: http://shiro.apache.org/permissions.html\n\n#
+        Attributes\n\n * name\n   - The tag for which to change the rule.\n   - This
+        attribute is required.\n   - It must be of type string.\n   - It must match
+        the name of an existing tag.\n\n * rule\n   - The new rule to apply to the
+        tag.\n   - This attribute is required.\n   - It must be of type array.\n\n
+        * force\n   - By default this command will fail if the tag is in use by an
+        existing\n     policy.  This flag allows you to override that, and force the
+        change to\n     apply despite the tag being in use.\n     \n     This will
+        not change policy binding of nodes, which may lead to some\n     counter-intuitive
+        results such as a node that does *not* match policy\n     tags being bound
+        to the policy.\n   - It must be of type boolean.\n","examples":{"api":"An
+        example of updating a tag rule, and forcing reevaluation:\n\n{\n  \"name\":
+        \"small\",\n  \"rule\": [\"<=\", [\"fact\", \"processorcount\"], \"2\"],\n  \"force\":
+        true\n}","cli":"An example of updating a tag rule, and forcing reevaluation:\n\nrazor
+        update-tag-rule --name small --force         --rule ''[\"<=\", [\"fact\",
+        \"processorcount\"], \"2\"]''"},"full":"# SYNOPSIS\nUpdate the matching rule
+        for an existing tag\n\n# DESCRIPTION\nThis will change the rule of the given
+        tag to the new rule. The tag will be\nreevaluated against all nodes and each
+        node''s tag attribute will be updated to\nreflect whether the tag now matches
+        or not, i.e., the tag will be added\nto/removed from each node''s tag as appropriate.\n\nIf
+        the tag is used by any policies, the update will only be performed if the\noptional
+        parameter `force` is set to `true`. Otherwise, it will fail.\n#<Razor::Validation::HashSchema:0x110c667>\n#
+        EXAMPLES\n\n  An example of updating a tag rule, and forcing reevaluation:\n  \n  {\n    \"name\":
+        \"small\",\n    \"rule\": [\"<=\", [\"fact\", \"processorcount\"], \"2\"],\n    \"force\":
+        true\n  }\n"},"schema":{"name":{"type":"string"},"rule":{"type":"array"},"force":{"type":"boolean"}}}'
+    http_version:
+  recorded_at: Mon, 25 Aug 2014 20:56:31 GMT
+recorded_with: VCR 2.9.2


### PR DESCRIPTION
The help text returned from the server used to just contain API-specific
examples. To facilitate CLI-specific examples, the help format is now
decomposed into pieces: "summary", "description", etc. This change displays
the pieces of the help, defaulting to showing CLI examples. API examples
can still be shown via the new `--api`/`-a` flag. The priority for what to
display is now this:
- Decomposed help + CLI examples
- Decomposed help + API examples (must have `--api`/`-a` flag)
- Unified help (included for backwards compatibility)

Fixes https://tickets.puppetlabs.com/browse/RAZOR-272
