### PR TITLE
Razor should throw error when help is requested but does not exist

### DIFF
--- a/lib/razor/cli/format.rb
+++ b/lib/razor/cli/format.rb
@@ -64,6 +64,7 @@ module Razor::CLI
 
     def format_command_help(doc, show_api_help)
       item = doc.items.first
+      raise Razor::CLI::Error, 'Could not find help for that entry' unless item.has_key?('help')
       if show_api_help and (item['help'].has_key?('summary') or item['help'].has_key?('description'))
         format_composed_help(item['help']).chomp
       elsif item['help'].has_key?('summary') or item['help'].has_key?('description')

--- a/spec/cli/format_spec.rb
+++ b/spec/cli/format_spec.rb
@@ -179,5 +179,11 @@ OUTPUT
       result.should =~ /summary here/
       result.should_not =~ /EXAMPLES/
     end
+
+    it "errors if help does not exist" do
+      doc = {"name"=>"some-help", "schema" => {"name"=>{"type"=>"string"}}}
+      expect { format doc, show_cli_help?: true, show_command_help?: true }.
+          to raise_error(Razor::CLI::Error, /Could not find help for that entry/)
+    end
   end
 end


### PR DESCRIPTION
When a help page is requested but does not exist, e.g. `razor nodes --help`,
the command is either executed anyway or an inaccurate error message is thrown.
This case should instead respond with a message like: "Could not find help for
that entry".

Fixes https://tickets.puppetlabs.com/browse/RAZOR-375
