### PR TITLE
Fix HTTPS certificate mismatch on localhost

### DIFF
--- a/lib/razor/cli/parse.rb
+++ b/lib/razor/cli/parse.rb
@@ -123,7 +123,8 @@ ERR
       # To be populated externally.
       @stripped_args = []
       @format = 'short'
-      @verify_ssl = true
+      # Localhost won't match the server's certificate; no verification required.
+      @verify_ssl = (@api_url.hostname != 'localhost')
       # If this is set, it should actually exist.
       if ENV['RAZOR_CA_FILE'] && !File.exists?(ENV['RAZOR_CA_FILE'])
         raise Razor::CLI::InvalidCAFileError.new(ENV['RAZOR_CA_FILE'])


### PR DESCRIPTION
The razor server is now supplying certificate information to allow SSL
communications. By default, without any override, razor-client's URL to
talk to the razor server is https://localhost:8151/api. That's fine, except
that the server's certificate won't typically use "localhost" as its fqdn, so
the razor client will not be able to authenticate its own certificate.

This uses localhost's FQDN rather than "localhost" to avoid this problem.

Fixes https://tickets.puppetlabs.com/browse/RAZOR-529