### PR TITLE
Handle non-string output from hook

### DIFF
--- a/lib/razor/cli/transforms.rb
+++ b/lib/razor/cli/transforms.rb
@@ -44,7 +44,7 @@ module Razor::CLI
     end
     def event_msg(obj)
       raise Razor::CLI::HideColumnError if obj['msg'].nil?
-      obj['msg'][0..50] + (obj['msg'].size > 50 ? '...' : '') if obj['msg']
+      obj['msg'].to_s[0..50] + (obj['msg'].to_s.size > 50 ? '...' : '')
     end
     def full_event_msg(obj)
       raise Razor::CLI::HideColumnError if obj['msg'].nil?


### PR DESCRIPTION
A hook can potentially output a datatype that is not a string. The view on
the client was previously assuming the 'msg' entry would be a string, so this
makes the display more generic.

Fixes https://tickets.puppetlabs.com/browse/RAZOR-545