### PR TITLE
Follow proper short form argument style

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,8 @@
 ## Next - Next
 
 * BUGFIX: Fixed insecure flag when supplied in addition to a server URL.
+* IMPROVEMENT: Proper short form argument style is now followed.
+  Single-character arguments now require a single dash, e.g. `-c`.
 * IMPROVEMENT: Error messaging for SSL issues has been improved.
 
 ## 1.1.0 - 2015-11-12

--- a/lib/razor/cli/command.rb
+++ b/lib/razor/cli/command.rb
@@ -37,6 +37,14 @@ class Razor::CLI::Command
         value = @segments.shift if value.nil? && @segments[0] !~ /^--/
         arg = self.class.resolve_alias(arg, @cmd_schema)
         body[arg] = self.class.convert_arg(arg, value, body[arg], @cmd_schema)
+      elsif argument =~ /\A-([a-z-]{2,})(=(.+))?\Z/ and
+            @cmd_schema[self.class.resolve_alias($1, @cmd_schema)]
+        # Short form, should be long; offer suggestion
+        raise ArgumentError, "Unexpected argument #{argument} (did you mean --#{$1}?)"
+      elsif argument =~ /\A--([a-z])(=(.+))?\Z/ and
+            @cmd_schema[self.class.resolve_alias($1, @cmd_schema)]
+        # Long form, should be short; offer suggestion
+        raise ArgumentError, "Unexpected argument #{argument} (did you mean -#{$1}?)"
       else
         raise ArgumentError, "Unexpected argument #{argument}"
       end

--- a/lib/razor/cli/navigate.rb
+++ b/lib/razor/cli/navigate.rb
@@ -93,7 +93,15 @@ module Razor::CLI
       elsif query?
         Razor::CLI::Query.new(@parse, self, collections, @segments).run
       elsif command?
-        Razor::CLI::Command.new(@parse, self, commands, @segments).run
+        cmd = @segments.shift
+        command = commands.find { |coll| coll["name"] == cmd }
+        cmd_url = URI.parse(command['id'])
+        # Ensure that we copy authentication data from our previous URL.
+        if @doc_resource
+          cmd_url = URI.parse(cmd_url.to_s)
+        end
+        command = json_get(cmd_url)
+        Razor::CLI::Command.new(@parse, self, command, @segments, cmd_url).run
       else
         raise NavigationError.new(@doc_resource, @segments, @doc)
       end

--- a/spec/cli/command_spec.rb
+++ b/spec/cli/command_spec.rb
@@ -63,4 +63,35 @@ describe Razor::CLI::Command do
       result.should == 'abc'
     end
   end
+
+  context "extract_command" do
+    it "fails with a single dash for long flags" do
+      c = Razor::CLI::Command.new(nil, nil, {'schema' => {'name' => {'type' => 'array'}}},
+                                  ['-name', 'abc'], '/foobar')
+      expect{c.extract_command}.
+          to raise_error(ArgumentError, 'Unexpected argument -name')
+    end
+    it "fails with a double dash for short flags" do
+      c = Razor::CLI::Command.new(nil, nil, {'schema' => {'n' => {'type' => 'array'}}},
+                                  ['--n', 'abc'], '/foobar')
+      expect{c.extract_command}.
+          to raise_error(ArgumentError, 'Unexpected argument --n')
+    end
+    it "fails with a double dash for short flags if argument does not exist" do
+      c = Razor::CLI::Command.new(nil, nil, {'schema' => {}},
+                                  ['--n', 'abc'], '/foobar')
+      expect{c.extract_command}.
+          to raise_error(ArgumentError, 'Unexpected argument --n')
+    end
+    it "succeeds with a double dash for long flags" do
+      c = Razor::CLI::Command.new(nil, nil, {'schema' => {'name' => {'type' => 'array'}}},
+                                  ['--name', 'abc'], '/foobar')
+      c.extract_command['name'].should == ['abc']
+    end
+    it "succeeds with a single dash for short flags" do
+      c = Razor::CLI::Command.new(nil, nil, {'schema' => {'n' => {'type' => 'array'}}},
+                                  ['-n', 'abc'], nil)
+      c.extract_command['n'].should == ['abc']
+    end
+  end
 end

--- a/spec/cli/command_spec.rb
+++ b/spec/cli/command_spec.rb
@@ -69,13 +69,13 @@ describe Razor::CLI::Command do
       c = Razor::CLI::Command.new(nil, nil, {'schema' => {'name' => {'type' => 'array'}}},
                                   ['-name', 'abc'], '/foobar')
       expect{c.extract_command}.
-          to raise_error(ArgumentError, 'Unexpected argument -name')
+          to raise_error(ArgumentError, 'Unexpected argument -name (did you mean --name?)')
     end
     it "fails with a double dash for short flags" do
       c = Razor::CLI::Command.new(nil, nil, {'schema' => {'n' => {'type' => 'array'}}},
                                   ['--n', 'abc'], '/foobar')
       expect{c.extract_command}.
-          to raise_error(ArgumentError, 'Unexpected argument --n')
+          to raise_error(ArgumentError, 'Unexpected argument --n (did you mean -n?)')
     end
     it "fails with a double dash for short flags if argument does not exist" do
       c = Razor::CLI::Command.new(nil, nil, {'schema' => {}},

--- a/spec/cli/navigate_spec.rb
+++ b/spec/cli/navigate_spec.rb
@@ -131,11 +131,11 @@ describe Razor::CLI::Navigate do
 
     it "should not allow double-dash with single character flag" do
       nav = Razor::CLI::Parse.new(['create-broker', '--name=some-broker', '--broker-type', 'puppet-pe', '--c', 'server=abc.com']).navigate
-      expect{nav.get_document}.to raise_error(ArgumentError, 'Unexpected argument --c')
+      expect{nav.get_document}.to raise_error(ArgumentError, 'Unexpected argument --c (did you mean -c?)')
     end
     it "should not allow single-dash with multiple character flag" do
       nav = Razor::CLI::Parse.new(['create-broker', '--name=some-broker', '-broker-type', 'puppet-pe']).navigate
-      expect{nav.get_document}.to raise_error(ArgumentError, 'Unexpected argument -broker-type')
+      expect{nav.get_document}.to raise_error(ArgumentError, 'Unexpected argument -broker-type (did you mean --broker-type?)')
     end
     it "should allow single-dash with single character flag" do
       Razor::CLI::Parse.new(['create-broker', '--name=some-broker', '--broker-type', 'puppet-pe', '-c', 'server=abc.com']).navigate.get_document['configuration']['server'].should == 'abc.com'

--- a/spec/cli/navigate_spec.rb
+++ b/spec/cli/navigate_spec.rb
@@ -128,6 +128,18 @@ describe Razor::CLI::Navigate do
     it "should allow '=' in string" do
       Razor::CLI::Parse.new(['create-repo', '--name=\'with=equals\'', '--url', 'http://url.com/some.iso', '--task', 'noop']).navigate.get_document['name'].should =~ /with=equals/
     end
+
+    it "should not allow double-dash with single character flag" do
+      nav = Razor::CLI::Parse.new(['create-broker', '--name=some-broker', '--broker-type', 'puppet-pe', '--c', 'server=abc.com']).navigate
+      expect{nav.get_document}.to raise_error(ArgumentError, 'Unexpected argument --c')
+    end
+    it "should not allow single-dash with multiple character flag" do
+      nav = Razor::CLI::Parse.new(['create-broker', '--name=some-broker', '-broker-type', 'puppet-pe']).navigate
+      expect{nav.get_document}.to raise_error(ArgumentError, 'Unexpected argument -broker-type')
+    end
+    it "should allow single-dash with single character flag" do
+      Razor::CLI::Parse.new(['create-broker', '--name=some-broker', '--broker-type', 'puppet-pe', '-c', 'server=abc.com']).navigate.get_document['configuration']['server'].should == 'abc.com'
+    end
   end
 
   context "for command help", :vcr do

--- a/spec/fixtures/vcr/Razor_CLI_Navigate/argument_formatting/should_allow_single-dash_with_single_character_flag.yml
+++ b/spec/fixtures/vcr/Razor_CLI_Navigate/argument_formatting/should_allow_single-dash_with_single_character_flag.yml
@@ -1,0 +1,203 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:8150/api
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json;charset=utf-8
+      Content-Length:
+      - '6471'
+      Date:
+      - Tue, 06 Oct 2015 23:42:04 GMT
+    body:
+      encoding: US-ASCII
+      string: '{"commands":[{"name":"add-policy-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/add-policy-tag","id":"http://localhost:8150/api/commands/add-policy-tag"},{"name":"create-broker","rel":"http://api.puppetlabs.com/razor/v1/commands/create-broker","id":"http://localhost:8150/api/commands/create-broker"},{"name":"create-hook","rel":"http://api.puppetlabs.com/razor/v1/commands/create-hook","id":"http://localhost:8150/api/commands/create-hook"},{"name":"create-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/create-policy","id":"http://localhost:8150/api/commands/create-policy"},{"name":"create-repo","rel":"http://api.puppetlabs.com/razor/v1/commands/create-repo","id":"http://localhost:8150/api/commands/create-repo"},{"name":"create-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/create-tag","id":"http://localhost:8150/api/commands/create-tag"},{"name":"create-task","rel":"http://api.puppetlabs.com/razor/v1/commands/create-task","id":"http://localhost:8150/api/commands/create-task"},{"name":"delete-broker","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-broker","id":"http://localhost:8150/api/commands/delete-broker"},{"name":"delete-hook","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-hook","id":"http://localhost:8150/api/commands/delete-hook"},{"name":"delete-node","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-node","id":"http://localhost:8150/api/commands/delete-node"},{"name":"delete-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-policy","id":"http://localhost:8150/api/commands/delete-policy"},{"name":"delete-repo","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-repo","id":"http://localhost:8150/api/commands/delete-repo"},{"name":"delete-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-tag","id":"http://localhost:8150/api/commands/delete-tag"},{"name":"disable-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/disable-policy","id":"http://localhost:8150/api/commands/disable-policy"},{"name":"enable-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/enable-policy","id":"http://localhost:8150/api/commands/enable-policy"},{"name":"modify-node-metadata","rel":"http://api.puppetlabs.com/razor/v1/commands/modify-node-metadata","id":"http://localhost:8150/api/commands/modify-node-metadata"},{"name":"modify-policy-max-count","rel":"http://api.puppetlabs.com/razor/v1/commands/modify-policy-max-count","id":"http://localhost:8150/api/commands/modify-policy-max-count"},{"name":"move-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/move-policy","id":"http://localhost:8150/api/commands/move-policy"},{"name":"reboot-node","rel":"http://api.puppetlabs.com/razor/v1/commands/reboot-node","id":"http://localhost:8150/api/commands/reboot-node"},{"name":"register-node","rel":"http://api.puppetlabs.com/razor/v1/commands/register-node","id":"http://localhost:8150/api/commands/register-node"},{"name":"reinstall-node","rel":"http://api.puppetlabs.com/razor/v1/commands/reinstall-node","id":"http://localhost:8150/api/commands/reinstall-node"},{"name":"remove-node-metadata","rel":"http://api.puppetlabs.com/razor/v1/commands/remove-node-metadata","id":"http://localhost:8150/api/commands/remove-node-metadata"},{"name":"remove-policy-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/remove-policy-tag","id":"http://localhost:8150/api/commands/remove-policy-tag"},{"name":"run-hook","rel":"http://api.puppetlabs.com/razor/v1/commands/run-hook","id":"http://localhost:8150/api/commands/run-hook"},{"name":"set-node-desired-power-state","rel":"http://api.puppetlabs.com/razor/v1/commands/set-node-desired-power-state","id":"http://localhost:8150/api/commands/set-node-desired-power-state"},{"name":"set-node-hw-info","rel":"http://api.puppetlabs.com/razor/v1/commands/set-node-hw-info","id":"http://localhost:8150/api/commands/set-node-hw-info"},{"name":"set-node-ipmi-credentials","rel":"http://api.puppetlabs.com/razor/v1/commands/set-node-ipmi-credentials","id":"http://localhost:8150/api/commands/set-node-ipmi-credentials"},{"name":"update-broker-configuration","rel":"http://api.puppetlabs.com/razor/v1/commands/update-broker-configuration","id":"http://localhost:8150/api/commands/update-broker-configuration"},{"name":"update-hook-configuration","rel":"http://api.puppetlabs.com/razor/v1/commands/update-hook-configuration","id":"http://localhost:8150/api/commands/update-hook-configuration"},{"name":"update-node-metadata","rel":"http://api.puppetlabs.com/razor/v1/commands/update-node-metadata","id":"http://localhost:8150/api/commands/update-node-metadata"},{"name":"update-policy-task","rel":"http://api.puppetlabs.com/razor/v1/commands/update-policy-task","id":"http://localhost:8150/api/commands/update-policy-task"},{"name":"update-repo-task","rel":"http://api.puppetlabs.com/razor/v1/commands/update-repo-task","id":"http://localhost:8150/api/commands/update-repo-task"},{"name":"update-tag-rule","rel":"http://api.puppetlabs.com/razor/v1/commands/update-tag-rule","id":"http://localhost:8150/api/commands/update-tag-rule"}],"collections":[{"name":"brokers","rel":"http://api.puppetlabs.com/razor/v1/collections/brokers","id":"http://localhost:8150/api/collections/brokers"},{"name":"repos","rel":"http://api.puppetlabs.com/razor/v1/collections/repos","id":"http://localhost:8150/api/collections/repos"},{"name":"tags","rel":"http://api.puppetlabs.com/razor/v1/collections/tags","id":"http://localhost:8150/api/collections/tags"},{"name":"policies","rel":"http://api.puppetlabs.com/razor/v1/collections/policies","id":"http://localhost:8150/api/collections/policies"},{"name":"nodes","rel":"http://api.puppetlabs.com/razor/v1/collections/nodes","id":"http://localhost:8150/api/collections/nodes","params":{"start":{"type":"number"},"limit":{"type":"number"}}},{"name":"tasks","rel":"http://api.puppetlabs.com/razor/v1/collections/tasks","id":"http://localhost:8150/api/collections/tasks"},{"name":"commands","rel":"http://api.puppetlabs.com/razor/v1/collections/commands","id":"http://localhost:8150/api/collections/commands"},{"name":"events","rel":"http://api.puppetlabs.com/razor/v1/collections/events","id":"http://localhost:8150/api/collections/events","params":{"start":{"type":"number"},"limit":{"type":"number"}}},{"name":"hooks","rel":"http://api.puppetlabs.com/razor/v1/collections/hooks","id":"http://localhost:8150/api/collections/hooks"}],"version":{"server":"v1.0.1-39-g2052ab6-dirty"}}'
+    http_version:
+  recorded_at: Tue, 06 Oct 2015 23:42:04 GMT
+- request:
+    method: get
+    uri: http://localhost:8150/api/commands/create-broker
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Etag:
+      - '"server-version-v1.0.1-39-g2052ab6-dirty"'
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json;charset=utf-8
+      Content-Length:
+      - '5184'
+      Date:
+      - Tue, 06 Oct 2015 23:42:04 GMT
+    body:
+      encoding: US-ASCII
+      string: '{"name":"create-broker","help":{"summary":"Create a new broker configuration
+        for hand-off of installed nodes","description":"Create a new broker configuration.  Brokers
+        are responsible for handing a node\noff to a config management system, such
+        as Puppet or Chef.  In cases where you\nhave no configuration management system,
+        you can use the `noop` broker.","schema":"# Access Control\n\nThis command''s
+        access control pattern: `commands:create-broker:%{name}`\n\nWords surrounded
+        by `%{...}` are substitutions from the input data: typically\nthe name of
+        the object being modified, or some other critical detail, these\nallow roles
+        to be granted partial access to modify the system.\n\nFor more detail on how
+        the permission strings are structured and work, you can\nsee the [Shiro Permissions
+        documentation][shiro].  That pattern is expanded\nand then a permission check
+        applied to it, before the command is authorized.\n\nThese checks only apply
+        if security is enabled in the Razor configuration\nfile; on this server security
+        is currently disabled.\n\n[shiro]: http://shiro.apache.org/permissions.html\n\n#
+        Attributes\n\n * name\n   - The name of the broker, as it will be referenced
+        within Razor.\n     This is the name that you supply to, eg, `create-policy`
+        to specify\n     which broker the node will be handed off via after installation.\n   -
+        This attribute is required.\n   - It must be of type string.\n   - It must
+        be between 1 and 250 in length.\n\n * broker_type\n   - The broker type from
+        which this broker is created.  The available\n     broker types on your server
+        are:\n     - chef\n     - noop\n     - puppet-pe\n     - puppet\n   - This
+        attribute is required.\n   - It must be of type string.\n   - It must match
+        the name of an existing broker type.\n\n * configuration\n   - The configuration
+        for the broker.  The acceptable values here are\n     determined by the `broker_type`
+        selected.  In general this has\n     settings like which server to contact,
+        and other configuration\n     related to handing on the newly installed system
+        to the final\n     configuration management system.\n     \n     This attribute
+        can be abbreviated as `c` for convenience.\n   - It must be of type object.\n","examples":{"api":"Creating
+        a simple Puppet broker:\n\n{\n  \"name\": \"puppet\",\n  \"configuration\":
+        {\n     \"server\":      \"puppet.example.org\",\n     \"environment\": \"production\"\n  },\n  \"broker_type\":
+        \"puppet\"\n}","cli":"Creating a simple Puppet broker:\n\nrazor create-broker
+        --name puppet -c server=puppet.example.org \\\n    -c environment=production
+        --broker-type puppet"},"full":"# SYNOPSIS\nCreate a new broker configuration
+        for hand-off of installed nodes\n\n# DESCRIPTION\nCreate a new broker configuration.  Brokers
+        are responsible for handing a node\noff to a config management system, such
+        as Puppet or Chef.  In cases where you\nhave no configuration management system,
+        you can use the `noop` broker.\n# Access Control\n\nThis command''s access
+        control pattern: `commands:create-broker:%{name}`\n\nWords surrounded by `%{...}`
+        are substitutions from the input data: typically\nthe name of the object being
+        modified, or some other critical detail, these\nallow roles to be granted
+        partial access to modify the system.\n\nFor more detail on how the permission
+        strings are structured and work, you can\nsee the [Shiro Permissions documentation][shiro].  That
+        pattern is expanded\nand then a permission check applied to it, before the
+        command is authorized.\n\nThese checks only apply if security is enabled in
+        the Razor configuration\nfile; on this server security is currently disabled.\n\n[shiro]:
+        http://shiro.apache.org/permissions.html\n\n# Attributes\n\n * name\n   -
+        The name of the broker, as it will be referenced within Razor.\n     This
+        is the name that you supply to, eg, `create-policy` to specify\n     which
+        broker the node will be handed off via after installation.\n   - This attribute
+        is required.\n   - It must be of type string.\n   - It must be between 1 and
+        250 in length.\n\n * broker_type\n   - The broker type from which this broker
+        is created.  The available\n     broker types on your server are:\n     -
+        chef\n     - noop\n     - puppet-pe\n     - puppet\n   - This attribute is
+        required.\n   - It must be of type string.\n   - It must match the name of
+        an existing broker type.\n\n * configuration\n   - The configuration for the
+        broker.  The acceptable values here are\n     determined by the `broker_type`
+        selected.  In general this has\n     settings like which server to contact,
+        and other configuration\n     related to handing on the newly installed system
+        to the final\n     configuration management system.\n     \n     This attribute
+        can be abbreviated as `c` for convenience.\n   - It must be of type object.\n\n#
+        EXAMPLES\n\n  Creating a simple Puppet broker:\n  \n  {\n    \"name\": \"puppet\",\n    \"configuration\":
+        {\n       \"server\":      \"puppet.example.org\",\n       \"environment\":
+        \"production\"\n    },\n    \"broker_type\": \"puppet\"\n  }\n"},"schema":{"name":{"type":"string"},"broker_type":{"type":"string","aliases":["broker-type"]},"configuration":{"type":"object","aliases":["c"]}}}'
+    http_version:
+  recorded_at: Tue, 06 Oct 2015 23:42:04 GMT
+- request:
+    method: post
+    uri: http://localhost:8150/api/commands/create-broker
+    body:
+      encoding: UTF-8
+      string: '{"name":"some-broker","broker_type":"puppet-pe","configuration":{"server":"abc.com"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '85'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json;charset=utf-8
+      Content-Length:
+      - '219'
+      Date:
+      - Tue, 06 Oct 2015 23:42:04 GMT
+    body:
+      encoding: US-ASCII
+      string: '{"spec":"http://api.puppetlabs.com/razor/v1/collections/brokers/member","id":"http://localhost:8150/api/collections/brokers/some-broker","name":"some-broker","command":"http://localhost:8150/api/collections/commands/1"}'
+    http_version:
+  recorded_at: Tue, 06 Oct 2015 23:42:05 GMT
+- request:
+    method: get
+    uri: http://localhost:8150/api/collections/brokers/some-broker
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json;charset=utf-8
+      Content-Length:
+      - '336'
+      Date:
+      - Tue, 06 Oct 2015 23:42:04 GMT
+    body:
+      encoding: US-ASCII
+      string: '{"spec":"http://api.puppetlabs.com/razor/v1/collections/brokers/member","id":"http://localhost:8150/api/collections/brokers/some-broker","name":"some-broker","configuration":{"server":"abc.com"},"broker_type":"puppet-pe","policies":{"id":"http://localhost:8150/api/collections/brokers/some-broker/policies","count":0,"name":"policies"}}'
+    http_version:
+  recorded_at: Tue, 06 Oct 2015 23:42:05 GMT
+recorded_with: VCR 2.5.0

--- a/spec/fixtures/vcr/Razor_CLI_Navigate/argument_formatting/should_not_allow_double-dash_with_single_character_flag.yml
+++ b/spec/fixtures/vcr/Razor_CLI_Navigate/argument_formatting/should_not_allow_double-dash_with_single_character_flag.yml
@@ -1,0 +1,133 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:8150/api
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json;charset=utf-8
+      Content-Length:
+      - '6471'
+      Date:
+      - Tue, 06 Oct 2015 23:41:59 GMT
+    body:
+      encoding: US-ASCII
+      string: '{"commands":[{"name":"add-policy-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/add-policy-tag","id":"http://localhost:8150/api/commands/add-policy-tag"},{"name":"create-broker","rel":"http://api.puppetlabs.com/razor/v1/commands/create-broker","id":"http://localhost:8150/api/commands/create-broker"},{"name":"create-hook","rel":"http://api.puppetlabs.com/razor/v1/commands/create-hook","id":"http://localhost:8150/api/commands/create-hook"},{"name":"create-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/create-policy","id":"http://localhost:8150/api/commands/create-policy"},{"name":"create-repo","rel":"http://api.puppetlabs.com/razor/v1/commands/create-repo","id":"http://localhost:8150/api/commands/create-repo"},{"name":"create-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/create-tag","id":"http://localhost:8150/api/commands/create-tag"},{"name":"create-task","rel":"http://api.puppetlabs.com/razor/v1/commands/create-task","id":"http://localhost:8150/api/commands/create-task"},{"name":"delete-broker","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-broker","id":"http://localhost:8150/api/commands/delete-broker"},{"name":"delete-hook","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-hook","id":"http://localhost:8150/api/commands/delete-hook"},{"name":"delete-node","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-node","id":"http://localhost:8150/api/commands/delete-node"},{"name":"delete-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-policy","id":"http://localhost:8150/api/commands/delete-policy"},{"name":"delete-repo","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-repo","id":"http://localhost:8150/api/commands/delete-repo"},{"name":"delete-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-tag","id":"http://localhost:8150/api/commands/delete-tag"},{"name":"disable-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/disable-policy","id":"http://localhost:8150/api/commands/disable-policy"},{"name":"enable-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/enable-policy","id":"http://localhost:8150/api/commands/enable-policy"},{"name":"modify-node-metadata","rel":"http://api.puppetlabs.com/razor/v1/commands/modify-node-metadata","id":"http://localhost:8150/api/commands/modify-node-metadata"},{"name":"modify-policy-max-count","rel":"http://api.puppetlabs.com/razor/v1/commands/modify-policy-max-count","id":"http://localhost:8150/api/commands/modify-policy-max-count"},{"name":"move-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/move-policy","id":"http://localhost:8150/api/commands/move-policy"},{"name":"reboot-node","rel":"http://api.puppetlabs.com/razor/v1/commands/reboot-node","id":"http://localhost:8150/api/commands/reboot-node"},{"name":"register-node","rel":"http://api.puppetlabs.com/razor/v1/commands/register-node","id":"http://localhost:8150/api/commands/register-node"},{"name":"reinstall-node","rel":"http://api.puppetlabs.com/razor/v1/commands/reinstall-node","id":"http://localhost:8150/api/commands/reinstall-node"},{"name":"remove-node-metadata","rel":"http://api.puppetlabs.com/razor/v1/commands/remove-node-metadata","id":"http://localhost:8150/api/commands/remove-node-metadata"},{"name":"remove-policy-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/remove-policy-tag","id":"http://localhost:8150/api/commands/remove-policy-tag"},{"name":"run-hook","rel":"http://api.puppetlabs.com/razor/v1/commands/run-hook","id":"http://localhost:8150/api/commands/run-hook"},{"name":"set-node-desired-power-state","rel":"http://api.puppetlabs.com/razor/v1/commands/set-node-desired-power-state","id":"http://localhost:8150/api/commands/set-node-desired-power-state"},{"name":"set-node-hw-info","rel":"http://api.puppetlabs.com/razor/v1/commands/set-node-hw-info","id":"http://localhost:8150/api/commands/set-node-hw-info"},{"name":"set-node-ipmi-credentials","rel":"http://api.puppetlabs.com/razor/v1/commands/set-node-ipmi-credentials","id":"http://localhost:8150/api/commands/set-node-ipmi-credentials"},{"name":"update-broker-configuration","rel":"http://api.puppetlabs.com/razor/v1/commands/update-broker-configuration","id":"http://localhost:8150/api/commands/update-broker-configuration"},{"name":"update-hook-configuration","rel":"http://api.puppetlabs.com/razor/v1/commands/update-hook-configuration","id":"http://localhost:8150/api/commands/update-hook-configuration"},{"name":"update-node-metadata","rel":"http://api.puppetlabs.com/razor/v1/commands/update-node-metadata","id":"http://localhost:8150/api/commands/update-node-metadata"},{"name":"update-policy-task","rel":"http://api.puppetlabs.com/razor/v1/commands/update-policy-task","id":"http://localhost:8150/api/commands/update-policy-task"},{"name":"update-repo-task","rel":"http://api.puppetlabs.com/razor/v1/commands/update-repo-task","id":"http://localhost:8150/api/commands/update-repo-task"},{"name":"update-tag-rule","rel":"http://api.puppetlabs.com/razor/v1/commands/update-tag-rule","id":"http://localhost:8150/api/commands/update-tag-rule"}],"collections":[{"name":"brokers","rel":"http://api.puppetlabs.com/razor/v1/collections/brokers","id":"http://localhost:8150/api/collections/brokers"},{"name":"repos","rel":"http://api.puppetlabs.com/razor/v1/collections/repos","id":"http://localhost:8150/api/collections/repos"},{"name":"tags","rel":"http://api.puppetlabs.com/razor/v1/collections/tags","id":"http://localhost:8150/api/collections/tags"},{"name":"policies","rel":"http://api.puppetlabs.com/razor/v1/collections/policies","id":"http://localhost:8150/api/collections/policies"},{"name":"nodes","rel":"http://api.puppetlabs.com/razor/v1/collections/nodes","id":"http://localhost:8150/api/collections/nodes","params":{"start":{"type":"number"},"limit":{"type":"number"}}},{"name":"tasks","rel":"http://api.puppetlabs.com/razor/v1/collections/tasks","id":"http://localhost:8150/api/collections/tasks"},{"name":"commands","rel":"http://api.puppetlabs.com/razor/v1/collections/commands","id":"http://localhost:8150/api/collections/commands"},{"name":"events","rel":"http://api.puppetlabs.com/razor/v1/collections/events","id":"http://localhost:8150/api/collections/events","params":{"start":{"type":"number"},"limit":{"type":"number"}}},{"name":"hooks","rel":"http://api.puppetlabs.com/razor/v1/collections/hooks","id":"http://localhost:8150/api/collections/hooks"}],"version":{"server":"v1.0.1-39-g2052ab6-dirty"}}'
+    http_version:
+  recorded_at: Tue, 06 Oct 2015 23:41:59 GMT
+- request:
+    method: get
+    uri: http://localhost:8150/api/commands/create-broker
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Etag:
+      - '"server-version-v1.0.1-39-g2052ab6-dirty"'
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json;charset=utf-8
+      Content-Length:
+      - '5184'
+      Date:
+      - Tue, 06 Oct 2015 23:41:59 GMT
+    body:
+      encoding: US-ASCII
+      string: '{"name":"create-broker","help":{"summary":"Create a new broker configuration
+        for hand-off of installed nodes","description":"Create a new broker configuration.  Brokers
+        are responsible for handing a node\noff to a config management system, such
+        as Puppet or Chef.  In cases where you\nhave no configuration management system,
+        you can use the `noop` broker.","schema":"# Access Control\n\nThis command''s
+        access control pattern: `commands:create-broker:%{name}`\n\nWords surrounded
+        by `%{...}` are substitutions from the input data: typically\nthe name of
+        the object being modified, or some other critical detail, these\nallow roles
+        to be granted partial access to modify the system.\n\nFor more detail on how
+        the permission strings are structured and work, you can\nsee the [Shiro Permissions
+        documentation][shiro].  That pattern is expanded\nand then a permission check
+        applied to it, before the command is authorized.\n\nThese checks only apply
+        if security is enabled in the Razor configuration\nfile; on this server security
+        is currently disabled.\n\n[shiro]: http://shiro.apache.org/permissions.html\n\n#
+        Attributes\n\n * name\n   - The name of the broker, as it will be referenced
+        within Razor.\n     This is the name that you supply to, eg, `create-policy`
+        to specify\n     which broker the node will be handed off via after installation.\n   -
+        This attribute is required.\n   - It must be of type string.\n   - It must
+        be between 1 and 250 in length.\n\n * broker_type\n   - The broker type from
+        which this broker is created.  The available\n     broker types on your server
+        are:\n     - chef\n     - noop\n     - puppet-pe\n     - puppet\n   - This
+        attribute is required.\n   - It must be of type string.\n   - It must match
+        the name of an existing broker type.\n\n * configuration\n   - The configuration
+        for the broker.  The acceptable values here are\n     determined by the `broker_type`
+        selected.  In general this has\n     settings like which server to contact,
+        and other configuration\n     related to handing on the newly installed system
+        to the final\n     configuration management system.\n     \n     This attribute
+        can be abbreviated as `c` for convenience.\n   - It must be of type object.\n","examples":{"api":"Creating
+        a simple Puppet broker:\n\n{\n  \"name\": \"puppet\",\n  \"configuration\":
+        {\n     \"server\":      \"puppet.example.org\",\n     \"environment\": \"production\"\n  },\n  \"broker_type\":
+        \"puppet\"\n}","cli":"Creating a simple Puppet broker:\n\nrazor create-broker
+        --name puppet -c server=puppet.example.org \\\n    -c environment=production
+        --broker-type puppet"},"full":"# SYNOPSIS\nCreate a new broker configuration
+        for hand-off of installed nodes\n\n# DESCRIPTION\nCreate a new broker configuration.  Brokers
+        are responsible for handing a node\noff to a config management system, such
+        as Puppet or Chef.  In cases where you\nhave no configuration management system,
+        you can use the `noop` broker.\n# Access Control\n\nThis command''s access
+        control pattern: `commands:create-broker:%{name}`\n\nWords surrounded by `%{...}`
+        are substitutions from the input data: typically\nthe name of the object being
+        modified, or some other critical detail, these\nallow roles to be granted
+        partial access to modify the system.\n\nFor more detail on how the permission
+        strings are structured and work, you can\nsee the [Shiro Permissions documentation][shiro].  That
+        pattern is expanded\nand then a permission check applied to it, before the
+        command is authorized.\n\nThese checks only apply if security is enabled in
+        the Razor configuration\nfile; on this server security is currently disabled.\n\n[shiro]:
+        http://shiro.apache.org/permissions.html\n\n# Attributes\n\n * name\n   -
+        The name of the broker, as it will be referenced within Razor.\n     This
+        is the name that you supply to, eg, `create-policy` to specify\n     which
+        broker the node will be handed off via after installation.\n   - This attribute
+        is required.\n   - It must be of type string.\n   - It must be between 1 and
+        250 in length.\n\n * broker_type\n   - The broker type from which this broker
+        is created.  The available\n     broker types on your server are:\n     -
+        chef\n     - noop\n     - puppet-pe\n     - puppet\n   - This attribute is
+        required.\n   - It must be of type string.\n   - It must match the name of
+        an existing broker type.\n\n * configuration\n   - The configuration for the
+        broker.  The acceptable values here are\n     determined by the `broker_type`
+        selected.  In general this has\n     settings like which server to contact,
+        and other configuration\n     related to handing on the newly installed system
+        to the final\n     configuration management system.\n     \n     This attribute
+        can be abbreviated as `c` for convenience.\n   - It must be of type object.\n\n#
+        EXAMPLES\n\n  Creating a simple Puppet broker:\n  \n  {\n    \"name\": \"puppet\",\n    \"configuration\":
+        {\n       \"server\":      \"puppet.example.org\",\n       \"environment\":
+        \"production\"\n    },\n    \"broker_type\": \"puppet\"\n  }\n"},"schema":{"name":{"type":"string"},"broker_type":{"type":"string","aliases":["broker-type"]},"configuration":{"type":"object","aliases":["c"]}}}'
+    http_version:
+  recorded_at: Tue, 06 Oct 2015 23:41:59 GMT
+recorded_with: VCR 2.5.0

--- a/spec/fixtures/vcr/Razor_CLI_Navigate/argument_formatting/should_not_allow_single-dash_with_multiple_character_flag.yml
+++ b/spec/fixtures/vcr/Razor_CLI_Navigate/argument_formatting/should_not_allow_single-dash_with_multiple_character_flag.yml
@@ -1,0 +1,133 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:8150/api
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '6470'
+      Date:
+      - Wed, 09 Dec 2015 01:27:48 GMT
+    body:
+      encoding: US-ASCII
+      string: '{"commands":[{"name":"add-policy-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/add-policy-tag","id":"http://localhost:8150/api/commands/add-policy-tag"},{"name":"create-broker","rel":"http://api.puppetlabs.com/razor/v1/commands/create-broker","id":"http://localhost:8150/api/commands/create-broker"},{"name":"create-hook","rel":"http://api.puppetlabs.com/razor/v1/commands/create-hook","id":"http://localhost:8150/api/commands/create-hook"},{"name":"create-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/create-policy","id":"http://localhost:8150/api/commands/create-policy"},{"name":"create-repo","rel":"http://api.puppetlabs.com/razor/v1/commands/create-repo","id":"http://localhost:8150/api/commands/create-repo"},{"name":"create-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/create-tag","id":"http://localhost:8150/api/commands/create-tag"},{"name":"create-task","rel":"http://api.puppetlabs.com/razor/v1/commands/create-task","id":"http://localhost:8150/api/commands/create-task"},{"name":"delete-broker","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-broker","id":"http://localhost:8150/api/commands/delete-broker"},{"name":"delete-hook","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-hook","id":"http://localhost:8150/api/commands/delete-hook"},{"name":"delete-node","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-node","id":"http://localhost:8150/api/commands/delete-node"},{"name":"delete-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-policy","id":"http://localhost:8150/api/commands/delete-policy"},{"name":"delete-repo","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-repo","id":"http://localhost:8150/api/commands/delete-repo"},{"name":"delete-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/delete-tag","id":"http://localhost:8150/api/commands/delete-tag"},{"name":"disable-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/disable-policy","id":"http://localhost:8150/api/commands/disable-policy"},{"name":"enable-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/enable-policy","id":"http://localhost:8150/api/commands/enable-policy"},{"name":"modify-node-metadata","rel":"http://api.puppetlabs.com/razor/v1/commands/modify-node-metadata","id":"http://localhost:8150/api/commands/modify-node-metadata"},{"name":"modify-policy-max-count","rel":"http://api.puppetlabs.com/razor/v1/commands/modify-policy-max-count","id":"http://localhost:8150/api/commands/modify-policy-max-count"},{"name":"move-policy","rel":"http://api.puppetlabs.com/razor/v1/commands/move-policy","id":"http://localhost:8150/api/commands/move-policy"},{"name":"reboot-node","rel":"http://api.puppetlabs.com/razor/v1/commands/reboot-node","id":"http://localhost:8150/api/commands/reboot-node"},{"name":"register-node","rel":"http://api.puppetlabs.com/razor/v1/commands/register-node","id":"http://localhost:8150/api/commands/register-node"},{"name":"reinstall-node","rel":"http://api.puppetlabs.com/razor/v1/commands/reinstall-node","id":"http://localhost:8150/api/commands/reinstall-node"},{"name":"remove-node-metadata","rel":"http://api.puppetlabs.com/razor/v1/commands/remove-node-metadata","id":"http://localhost:8150/api/commands/remove-node-metadata"},{"name":"remove-policy-tag","rel":"http://api.puppetlabs.com/razor/v1/commands/remove-policy-tag","id":"http://localhost:8150/api/commands/remove-policy-tag"},{"name":"run-hook","rel":"http://api.puppetlabs.com/razor/v1/commands/run-hook","id":"http://localhost:8150/api/commands/run-hook"},{"name":"set-node-desired-power-state","rel":"http://api.puppetlabs.com/razor/v1/commands/set-node-desired-power-state","id":"http://localhost:8150/api/commands/set-node-desired-power-state"},{"name":"set-node-hw-info","rel":"http://api.puppetlabs.com/razor/v1/commands/set-node-hw-info","id":"http://localhost:8150/api/commands/set-node-hw-info"},{"name":"set-node-ipmi-credentials","rel":"http://api.puppetlabs.com/razor/v1/commands/set-node-ipmi-credentials","id":"http://localhost:8150/api/commands/set-node-ipmi-credentials"},{"name":"update-broker-configuration","rel":"http://api.puppetlabs.com/razor/v1/commands/update-broker-configuration","id":"http://localhost:8150/api/commands/update-broker-configuration"},{"name":"update-hook-configuration","rel":"http://api.puppetlabs.com/razor/v1/commands/update-hook-configuration","id":"http://localhost:8150/api/commands/update-hook-configuration"},{"name":"update-node-metadata","rel":"http://api.puppetlabs.com/razor/v1/commands/update-node-metadata","id":"http://localhost:8150/api/commands/update-node-metadata"},{"name":"update-policy-task","rel":"http://api.puppetlabs.com/razor/v1/commands/update-policy-task","id":"http://localhost:8150/api/commands/update-policy-task"},{"name":"update-repo-task","rel":"http://api.puppetlabs.com/razor/v1/commands/update-repo-task","id":"http://localhost:8150/api/commands/update-repo-task"},{"name":"update-tag-rule","rel":"http://api.puppetlabs.com/razor/v1/commands/update-tag-rule","id":"http://localhost:8150/api/commands/update-tag-rule"}],"collections":[{"name":"brokers","rel":"http://api.puppetlabs.com/razor/v1/collections/brokers","id":"http://localhost:8150/api/collections/brokers"},{"name":"repos","rel":"http://api.puppetlabs.com/razor/v1/collections/repos","id":"http://localhost:8150/api/collections/repos"},{"name":"tags","rel":"http://api.puppetlabs.com/razor/v1/collections/tags","id":"http://localhost:8150/api/collections/tags"},{"name":"policies","rel":"http://api.puppetlabs.com/razor/v1/collections/policies","id":"http://localhost:8150/api/collections/policies"},{"name":"nodes","rel":"http://api.puppetlabs.com/razor/v1/collections/nodes","id":"http://localhost:8150/api/collections/nodes","params":{"start":{"type":"number"},"limit":{"type":"number"}}},{"name":"tasks","rel":"http://api.puppetlabs.com/razor/v1/collections/tasks","id":"http://localhost:8150/api/collections/tasks"},{"name":"commands","rel":"http://api.puppetlabs.com/razor/v1/collections/commands","id":"http://localhost:8150/api/collections/commands"},{"name":"events","rel":"http://api.puppetlabs.com/razor/v1/collections/events","id":"http://localhost:8150/api/collections/events","params":{"start":{"type":"number"},"limit":{"type":"number"}}},{"name":"hooks","rel":"http://api.puppetlabs.com/razor/v1/collections/hooks","id":"http://localhost:8150/api/collections/hooks"}],"version":{"server":"v1.1.0-4-gbc32aac-dirty"}}'
+    http_version:
+  recorded_at: Wed, 09 Dec 2015 01:27:48 GMT
+- request:
+    method: get
+    uri: http://localhost:8150/api/commands/create-broker
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Etag:
+      - '"server-version-v1.1.0-4-gbc32aac-dirty"'
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '5210'
+      Date:
+      - Wed, 09 Dec 2015 01:27:48 GMT
+    body:
+      encoding: US-ASCII
+      string: '{"name":"create-broker","help":{"summary":"Create a new broker configuration
+        for hand-off of installed nodes","description":"Create a new broker configuration.  Brokers
+        are responsible for handing a node\noff to a config management system, such
+        as Puppet or Chef.  In cases where you\nhave no configuration management system,
+        you can use the `noop` broker.","schema":"# Access Control\n\nThis command''s
+        access control pattern: `commands:create-broker:%{name}`\n\nWords surrounded
+        by `%{...}` are substitutions from the input data: typically\nthe name of
+        the object being modified, or some other critical detail, these\nallow roles
+        to be granted partial access to modify the system.\n\nFor more detail on how
+        the permission strings are structured and work, you can\nsee the [Shiro Permissions
+        documentation][shiro].  That pattern is expanded\nand then a permission check
+        applied to it, before the command is authorized.\n\nThese checks only apply
+        if security is enabled in the Razor configuration\nfile; on this server security
+        is currently disabled.\n\n[shiro]: http://shiro.apache.org/permissions.html\n\n#
+        Attributes\n\n * name\n   - The name of the broker, as it will be referenced
+        within Razor.\n     This is the name that you supply to, eg, `create-policy`
+        to specify\n     which broker the node will be handed off via after installation.\n   -
+        This attribute is required.\n   - It must be of type string.\n   - It must
+        be between 1 and 250 in length.\n\n * broker_type\n   - The broker type from
+        which this broker is created.  The available\n     broker types on your server
+        are:\n     - chef\n     - noop\n     - puppet-pe\n     - puppet\n   - This
+        attribute is required.\n   - It must be of type string.\n   - It must match
+        the name of an existing broker type.\n\n * configuration\n   - The configuration
+        for the broker.  The acceptable values here are\n     determined by the `broker_type`
+        selected.  In general this has\n     settings like which server to contact,
+        and other configuration\n     related to handing on the newly installed system
+        to the final\n     configuration management system.\n     \n     This attribute
+        can be abbreviated as `c` for convenience.\n   - It must be of type object.\n","examples":{"api":"Creating
+        a simple Puppet broker:\n\n{\n  \"name\": \"puppet\",\n  \"configuration\":
+        {\n     \"server\":      \"puppet.example.org\",\n     \"environment\": \"production\"\n  },\n  \"broker_type\":
+        \"puppet\"\n}","cli":"Creating a simple Puppet broker:\n\nrazor create-broker
+        --name puppet -c server=puppet.example.org \\\n    -c environment=production
+        --broker-type puppet"},"full":"# SYNOPSIS\nCreate a new broker configuration
+        for hand-off of installed nodes\n\n# DESCRIPTION\nCreate a new broker configuration.  Brokers
+        are responsible for handing a node\noff to a config management system, such
+        as Puppet or Chef.  In cases where you\nhave no configuration management system,
+        you can use the `noop` broker.\n# Access Control\n\nThis command''s access
+        control pattern: `commands:create-broker:%{name}`\n\nWords surrounded by `%{...}`
+        are substitutions from the input data: typically\nthe name of the object being
+        modified, or some other critical detail, these\nallow roles to be granted
+        partial access to modify the system.\n\nFor more detail on how the permission
+        strings are structured and work, you can\nsee the [Shiro Permissions documentation][shiro].  That
+        pattern is expanded\nand then a permission check applied to it, before the
+        command is authorized.\n\nThese checks only apply if security is enabled in
+        the Razor configuration\nfile; on this server security is currently disabled.\n\n[shiro]:
+        http://shiro.apache.org/permissions.html\n\n# Attributes\n\n * name\n   -
+        The name of the broker, as it will be referenced within Razor.\n     This
+        is the name that you supply to, eg, `create-policy` to specify\n     which
+        broker the node will be handed off via after installation.\n   - This attribute
+        is required.\n   - It must be of type string.\n   - It must be between 1 and
+        250 in length.\n\n * broker_type\n   - The broker type from which this broker
+        is created.  The available\n     broker types on your server are:\n     -
+        chef\n     - noop\n     - puppet-pe\n     - puppet\n   - This attribute is
+        required.\n   - It must be of type string.\n   - It must match the name of
+        an existing broker type.\n\n * configuration\n   - The configuration for the
+        broker.  The acceptable values here are\n     determined by the `broker_type`
+        selected.  In general this has\n     settings like which server to contact,
+        and other configuration\n     related to handing on the newly installed system
+        to the final\n     configuration management system.\n     \n     This attribute
+        can be abbreviated as `c` for convenience.\n   - It must be of type object.\n\n#
+        EXAMPLES\n\n  Creating a simple Puppet broker:\n  \n  {\n    \"name\": \"puppet\",\n    \"configuration\":
+        {\n       \"server\":      \"puppet.example.org\",\n       \"environment\":
+        \"production\"\n    },\n    \"broker_type\": \"puppet\"\n  }\n"},"schema":{"name":{"type":"string","position":0},"broker_type":{"type":"string","aliases":["broker-type"],"position":1},"configuration":{"type":"object","aliases":["c"]}}}'
+    http_version:
+  recorded_at: Wed, 09 Dec 2015 01:27:48 GMT
+recorded_with: VCR 2.5.0


### PR DESCRIPTION
Short form flags/arguments are typically invoked using a single dash followed
by a single character. This didn't work previously, requiring two dashes. The
rule here is that if the argument is one character long, a single dash should
be used and is all that will be accepted.

Fixes https://tickets.puppetlabs.com/browse/RAZOR-566