### PR TITLE
Allow ruby 1.8.7

### DIFF
--- a/lib/razor/cli/navigate.rb
+++ b/lib/razor/cli/navigate.rb
@@ -3,6 +3,42 @@ require 'multi_json'
 require 'yaml'
 require 'forwardable'
 
+# Needed to make the client work on Ruby 1.8.7
+unless URI.respond_to?(:encode_www_form)
+  module URI
+    def self.encode_www_form_component(str)
+      str = str.to_s
+      if HTML5ASCIIINCOMPAT.include?(str.encoding)
+        str = str.encode(Encoding::UTF_8)
+      else
+        str = str.dup
+      end
+      str.force_encoding(Encoding::ASCII_8BIT)
+      str.gsub!(/[^*\-.0-9A-Z_a-z]/, TBLENCWWWCOMP_)
+      str.force_encoding(Encoding::US_ASCII)
+    end
+    def self.encode_www_form(enum)
+      enum.map do |k,v|
+        if v.nil?
+          encode_www_form_component(k)
+        elsif v.respond_to?(:to_ary)
+          v.to_ary.map do |w|
+            str = encode_www_form_component(k)
+            unless w.nil?
+              str << '='
+              str << encode_www_form_component(w)
+            end
+          end.join('&')
+        else
+          str = encode_www_form_component(k)
+          str << '='
+          str << encode_www_form_component(v)
+        end
+      end.join('&')
+    end
+  end
+end
+
 module Razor::CLI
   class Navigate
     extend Forwardable

--- a/lib/razor/cli/parse.rb
+++ b/lib/razor/cli/parse.rb
@@ -2,6 +2,16 @@ require 'uri'
 require 'optparse'
 require 'forwardable'
 
+# Needed to make the client work on Ruby 1.8.7
+unless URI::Generic.method_defined?(:hostname)
+  module URI
+    def hostname
+      v = self.host
+      /\A\[(.*)\]\z/ =~ v ? $1 : v
+    end
+  end
+end
+
 module Razor::CLI
 
   class Parse


### PR DESCRIPTION
This monkey-patches two methods that are absent from Ruby 1.8.7:
- URI.encode_www_form
- URI.hostname

Fixes https://tickets.puppetlabs.com/browse/RAZOR-572