### PR TITLE
SSL Improvement

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 ## Next - Next
 
+* BUGFIX: Fixed insecure flag when supplied in addition to a server URL.
 * IMPROVEMENT: Error messaging for SSL issues has been improved.
 
 ## 1.1.0 - 2015-11-12

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # Razor Client Release Notes
 
+## Next - Next
+
+* IMPROVEMENT: Error messaging for SSL issues has been improved.
+
 ## 1.1.0 - 2015-11-12
 
 * IMPROVEMENT: By default, `razor` will point to port 8150.

--- a/lib/razor/cli/parse.rb
+++ b/lib/razor/cli/parse.rb
@@ -105,10 +105,23 @@ HELP
 Error: Credentials are required to connect to the server at #{@api_url}"
 UNAUTH
         exit = 1
-      rescue
+      rescue SocketError, Errno::ECONNREFUSED => e
+        puts "Error: Could not connect to the server at #{@api_url}"
+        puts "       #{e}\n"
+        die
+      rescue RestClient::SSLCertificateNotVerified
+        puts "Error: SSL certificate could not be verified against known CA certificates."
+        puts "       To turn off verification, use the -k or --insecure option."
+        die
+      rescue OpenSSL::SSL::SSLError => e
+        # Occurs in case of e.g. certificate mismatch (FQDN vs. hostname)
+        puts "Error: SSL certificate error from server at #{@api_url}"
+        puts "       #{e}"
+        die
+      rescue => e
         output << <<-ERR
-Error: Could not connect to the server at #{@api_url}. More help is available after pointing
-the client to a Razor server
+Error: Unknown error occurred while connecting to server at #{@api_url}:
+       #{e}
 ERR
         exit = 1
       end

--- a/lib/razor/cli/parse.rb
+++ b/lib/razor/cli/parse.rb
@@ -164,6 +164,7 @@ ERR
       # To be populated externally.
       @stripped_args = []
       @format = 'short'
+      @verify_ssl = true
       env_pem_file = ENV['RAZOR_CA_FILE']
       # If this is set, it should actually exist.
       if env_pem_file && !File.exists?(env_pem_file)
@@ -180,7 +181,9 @@ ERR
 
       # Localhost won't match the server's certificate; no verification required.
       # This needs to happen after get_optparse so `-k` and `-u` can take effect.
-      @verify_ssl ||= (@api_url.hostname != 'localhost')
+      if @api_url.hostname == 'localhost'
+        @verify_ssl = false
+      end
 
       @args = set_help_vars(@args)
       if @args == ['version'] or @show_version

--- a/spec/cli/parse_spec.rb
+++ b/spec/cli/parse_spec.rb
@@ -57,6 +57,11 @@ describe Razor::CLI::Parse do
         parse('-u',url).verify_ssl?.should == true
       end
 
+      it "should respect insecure requests" do
+        url = 'http://razor.example.com:2150/path/to/api'
+        parse('-u',url,'-k').verify_ssl?.should be false
+      end
+
       it "should terminate with an error if an invalid URL is provided" do
         expect{parse('-u','not valid url')}.to raise_error(Razor::CLI::InvalidURIError)
       end


### PR DESCRIPTION
This resolves two main issues:
- (RAZOR-662) There are a few standardized locations on Linux and Windows that can be
checked for TLS/SSL communication. This adds those checks, in the case that
those exist, so that HTTPS communication will just work out-of-the-box.
- (RAZOR-661) The logic behind SSL verification was overriding the supplied `-k` flag. This
resolves that issue and makes the logic a bit more straightforward.

An extra SSL-related issue has been bundled in here too.