### PR TITLE
(maint) remove apt and yum path from build_defaults

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -11,12 +11,10 @@ sign_tar: FALSE
 # a space separated list of mock configs
 final_mocks: ''
 yum_host: 'yum.puppetlabs.com'
-yum_repo_path: '/opt/repository/yum/'
 build_gem: TRUE
 build_dmg: FALSE
 build_ips: FALSE
 build_pe:  FALSE
 apt_host: 'apt.puppetlabs.com'
 apt_repo_url: 'http://apt.puppetlabs.com'
-apt_repo_path: '/opt/repository/incoming'
 tar_host: 'downloads.puppetlabs.com'


### PR DESCRIPTION
Razor isn't shipping to anywhere special so we shouldn't be setting the
apt and yum paths.