### PR TITLE
Report razor-client version even if razor-server is unreachable

### DIFF
--- a/bin/razor
+++ b/bin/razor
@@ -28,8 +28,9 @@ rescue OptionParser::InvalidOption => e
 end
 
 if parse.show_version?
-  puts parse.version
-  exit 0
+  version, exit_code = parse.version
+  puts version
+  exit exit_code
 end
 
 if parse.show_help? and not parse.show_command_help?

--- a/lib/razor/cli/parse.rb
+++ b/lib/razor/cli/parse.rb
@@ -63,22 +63,19 @@ module Razor::CLI
     end
 
     def version
+      server_version = '(unknown)'
+      error = ''
       begin
-      <<-VERSION
-Razor Server version: #{navigate.server_version}
-Razor Client version: #{Razor::CLI::VERSION}
-      VERSION
+        server_version = navigate.server_version
       rescue RestClient::Unauthorized
-        puts <<-UNAUTH
-Error: Credentials are required to connect to the server at #{@api_url}"
-        UNAUTH
-        exit 1
+        error = "Error: Credentials are required to connect to the server at #{@api_url}."
       rescue
-        puts <<-ERR
-Error: Could not connect to the server at #{@api_url}. More help is available after pointing
-the client to a Razor server
-        ERR
-        exit 1
+        error = "Error: Could not connect to the server at #{@api_url}."
+      ensure
+        return [(<<-OUTPUT + "\n" + error).rstrip, error != '' ? 1 : 0]
+        Razor Server version: #{server_version}
+        Razor Client version: #{Razor::CLI::VERSION}
+        OUTPUT
       end
     end
 

--- a/spec/cli/parse_spec.rb
+++ b/spec/cli/parse_spec.rb
@@ -91,6 +91,12 @@ describe Razor::CLI::Parse do
       it {parse("--version").show_version?.should be true}
     end
 
+    context "with '--version' and no reachable server" do
+      subject { parse("--version", '-u', 'https://localhost:9999999/api').version.first }
+      it { should =~ /Razor Server version: \(unknown\)/ }
+      it { should =~ /Razor Client version: #{Razor::CLI::VERSION}/ }
+    end
+
     context "with ENV RAZOR_API set" do
       it "should use the given URL" do
         url = 'http://razor.example.com:2150/env/path/to/api'


### PR DESCRIPTION
When the razor-client ran with `--version` and the Razor server was unreachable,
an error message was displayed and no client version was output. This is
annoying if the user just wants to check its client version.

The desired behavior, now implemented, is to display the client version
regardless, then show a connection error.

Fixes https://tickets.puppetlabs.com/browse/RAZOR-627