### PR TITLE
Allow underscores in arguments

### DIFF
--- a/lib/razor/cli/command.rb
+++ b/lib/razor/cli/command.rb
@@ -30,15 +30,15 @@ class Razor::CLI::Command
     pos_index = 0
     until @segments.empty?
       argument = @segments.shift
-      if argument =~ /\A--([a-z-]{2,})(=(.+))?\Z/ or
+      if argument =~ /\A--([a-z][a-z_-]+)(=(.+))?\Z/ or
           argument =~ /\A-([a-z])(=(.+))?\Z/
         # `--arg=value`/`--arg value`
         # `-a=value`/`-a value`
         arg_name, value = [$1, $3]
-        value = @segments.shift if value.nil? && @segments[0] !~ /^--/
+        value = @segments.shift if value.nil? && @segments[0] !~ /^-/
         arg_name = self.class.resolve_alias(arg_name, @cmd_schema)
         body[arg_name] = self.class.convert_arg(arg_name, value, body[arg_name], @cmd_schema)
-      elsif argument =~ /\A-([a-z-]{2,})(=(.+))?\Z/ and
+      elsif argument =~ /\A-([a-z][a-z_-]+)(=(.+))?\Z/ and
             @cmd_schema[self.class.resolve_alias($1, @cmd_schema)]
         # Short form, should be long; offer suggestion
         raise ArgumentError, "Unexpected argument #{argument} (did you mean --#{$1}?)"

--- a/spec/cli/command_spec.rb
+++ b/spec/cli/command_spec.rb
@@ -71,7 +71,6 @@ describe Razor::CLI::Command do
       c.extract_command
     end
     context "flag length" do
-
       it "fails with a single dash for long flags" do
         expect{extract({'schema' => {'name' => {'type' => 'array'}}}, ['-name', 'abc'])}.
             to raise_error(ArgumentError, 'Unexpected argument -name (did you mean --name?)')
@@ -95,6 +94,16 @@ describe Razor::CLI::Command do
                                     ['-n', 'abc'], nil)
         extract({'schema' => {'n' => {'type' => 'array'}}}, ['-n', 'abc'])['n'].should == ['abc']
       end
+    end
+
+    it "handles all reasonable characters" do
+      def generate_arg
+        prng = Random.new
+        [*'a'..'z'].shuffle(random: prng).first +
+            [*'a'..'z', '-', '_'].shuffle(random:prng).join
+      end
+      arg = generate_arg
+      extract({'schema' => {arg => {'type' => 'array'}}}, ["--#{arg}", 'abc'])[arg].should == ['abc']
     end
 
     context "positional arguments" do

--- a/spec/cli/navigate_spec.rb
+++ b/spec/cli/navigate_spec.rb
@@ -42,8 +42,8 @@ describe Razor::CLI::Navigate do
     end
 
     it "should fail with malformed argument" do
-      nav = Razor::CLI::Parse.new(['create-tag', '--name', 'tag_2', '--inva_lid']).navigate
-      expect{nav.get_document}.to raise_error(ArgumentError, /Unexpected argument --inva_lid/)
+      nav = Razor::CLI::Parse.new(['create-tag', '--name', 'tag_2', '--inva^lid']).navigate
+      expect{nav.get_document}.to raise_error(ArgumentError, /Unexpected argument --inva\^lid/)
     end
   end
 


### PR DESCRIPTION
Although the recommended practice is using dashes for property names, it
makes sense to allow the user to enter in underscores in their place, since
the documentation describes properties as having underscores.

Fixes https://tickets.puppetlabs.com/browse/RAZOR-842
