### PR TITLE
Scope individual properties

### DIFF
--- a/lib/razor/cli/document.rb
+++ b/lib/razor/cli/document.rb
@@ -4,21 +4,24 @@ module Razor::CLI
   class HideColumnError < RuntimeError; end
   class Document
       extend Forwardable
-    attr_reader 'spec', 'items', 'format_view', 'original_items'
+    attr_reader 'spec', 'type', 'items', 'format_view', 'original_items',
+                'command'
     def initialize(doc, format_type)
-      if doc['spec'].is_a?(Array)
-        @spec, @remaining_navigation = doc['spec']
-      else
-        @spec = doc['spec']
+      @type = :single
+      if doc.is_a?(Hash)
+        if doc['+spec'].is_a?(Array)
+          @spec, remaining_navigation = doc['+spec']
+        else
+          @spec = doc['spec']
+        end
+        @command = doc['command']
+        if doc.has_key?('items')
+          @type = :list
+          @items = doc['items']
+        end
       end
-      @command = doc['command']
-      if doc.has_key?('items')
-        @type = :list
-      else
-        @type = :single
-      end
-      @items = doc['items'] || Array[doc]
-      @format_view = Razor::CLI::Views.find_formatting(@spec, format_type, @remaining_navigation)
+      @items ||= Array[doc]
+      @format_view = Razor::CLI::Views.find_formatting(@spec, format_type, remaining_navigation)
 
       # Untransformed and unordered for displaying nested views.
       @original_items = @items

--- a/lib/razor/cli/format.rb
+++ b/lib/razor/cli/format.rb
@@ -50,7 +50,7 @@ module Razor::CLI
     # We assume that all collections are homogenous
     def format_objects(objects, indent = 0)
       objects.map do |obj|
-        obj.is_a?(Hash) ? format_object(obj, indent) : ' '*indent + obj.inspect
+        obj.is_a?(Hash) ? format_object(obj, indent) : ' '*indent + obj.to_s
       end.join "\n\n"
     end
 
@@ -143,7 +143,7 @@ module Razor::CLI
         else
           case f
           when "spec" then "\"#{Format.spec_name(value)}\""
-          else value.inspect
+          else value.to_s # Could be `false` or `nil` possibly
           end
         end
       end.join "\n"

--- a/lib/razor/cli/views.rb
+++ b/lib/razor/cli/views.rb
@@ -1,6 +1,9 @@
 module Razor::CLI
   module Views
     module_function
+    def views= v
+      @views = v
+    end
     def views
       @views ||= YAML::load_file(File::join(File::dirname(__FILE__), "views.yaml"))
     end

--- a/lib/razor/cli/views.yaml
+++ b/lib/razor/cli/views.yaml
@@ -78,7 +78,6 @@ collections:
       +short:
         +layout: table
         +show:
-          name:
           timestamp:
           severity:
           event:
@@ -253,3 +252,6 @@ collections:
           name:
           hook_type:
           configuration:
+  config:
+    +short:
+      +layout: table

--- a/spec/cli/document_spec.rb
+++ b/spec/cli/document_spec.rb
@@ -1,0 +1,46 @@
+# -*- encoding: utf-8 -*-
+# Needed to make the client work on Ruby 1.8.7
+unless Kernel.respond_to?(:require_relative)
+  module Kernel
+    def require_relative(path)
+      require File.join(File.dirname(caller[0]), path.to_str)
+    end
+  end
+end
+
+require_relative '../spec_helper'
+
+describe Razor::CLI::Document do
+  def document(doc, format_type)
+    Razor::CLI::Document.new(doc, format_type)
+  end
+  def check_doc(reality, expectation)
+    [:spec, :items, :type, :format_view, :command].each do |prop|
+      reality.public_send(prop).should == expectation[prop] if expectation[prop]
+    end
+  end
+  describe "#new" do
+    it "creates a blank document successfully" do
+      doc = document({}, 'short')
+      check_doc(doc, items: [{}], type: :single)
+    end
+    it "creates a normal document successfully" do
+      doc = document({'spec' => 'some/path', 'abc' => 'def'}, 'short')
+      check_doc(doc, type: :single, spec: 'some/path')
+    end
+    it "includes the command if supplied" do
+      doc = document({'spec' => 'some/path', 'abc' => 'def', 'command' => 123}, 'short')
+      check_doc(doc, type: :single, spec: 'some/path', command: 123)
+    end
+    it "finds formatting based on the spec string" do
+      Razor::CLI::Views.views = {'collections' => {'item' => {'+short' => {'+layout' => 'list'}}}}
+      doc = document({'spec' => '/collections/item', 'abc' => 'def'}, 'short')
+      check_doc(doc, type: :single, spec: '/collections/item', format_view: {'+layout' => 'list'})
+    end
+    it "finds formatting based on the spec array" do
+      Razor::CLI::Views.views = {'collections' => {'more' => {'scoping' => {'+short' => {'+layout' => 'list'}}}}}
+      doc = document({'+spec' => ['/collections/more', 'scoping'], 'abc' => 'def'}, 'short')
+      check_doc(doc, type: :single, spec: '/collections/more', format_view: {'+layout' => 'list'})
+    end
+  end
+end

--- a/spec/cli/format_spec.rb
+++ b/spec/cli/format_spec.rb
@@ -42,11 +42,6 @@ describe Razor::CLI::Format do
       result = format doc
       result.should_not =~ /Query additional details/
     end
-    it "hides array spec array from additional details" do
-      doc = {'abc' => [], 'spec' => ['def', 'jkl']}
-      result = format doc
-      result.should =~ /Query additional details via: `razor something else \[abc\]`\z/
-    end
     it "hides array +spec array from additional details" do
       doc = {'abc' => [], '+spec' => ['def', 'jkl']}
       result = format doc


### PR DESCRIPTION
If the user scopes to a specific property, the client shouldn't fail to
reveal it. Given a server response of {"attr": {"sub-attr": "value"} and a
`razor attr sub-attr`, "value" should be returned. This previously caused an
exception in the code.

The display for `razor config` should be more clean than it is, displaying a
table view instead of a list view.

Fixes https://tickets.puppetlabs.com/browse/RAZOR-531