### PR TITLE
Use gettext-setup gem for internationalization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
-config.yaml
 log/*
 pkg/
+/config.yaml
 /.yardoc
 /Gemfile.local*
 /coverage

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,9 @@ gem 'mime-types', '< 2.0'
 # `rest-client` adds an undesirable dependency on Ruby >= 1.9.2 in version 1.7.0.
 gem 'rest-client', '< 1.7'
 gem 'command_line_reporter', '>=3.0'
+gem 'gettext-setup'
+gem 'rack', '< 2.0.0'
+gem 'multi_json'
 
 group :doc do
   gem 'yard'
@@ -14,6 +17,7 @@ end
 
 # This group will be excluded by default in `torquebox archive`
 group :test do
+  gem 'public_suffix', '~> 1.4.6'
   gem 'rack-test'
   gem 'rspec', '~> 2.13.0'
   gem 'rspec-core', '~> 2.13.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,9 +7,18 @@ GEM
       colored (>= 1.2)
     crack (0.3.2)
     diff-lcs (1.2.4)
+    fast_gettext (1.1.0)
+    gettext (3.2.2)
+      locale (>= 2.0.5)
+      text (>= 1.3.0)
+    gettext-setup (0.11)
+      fast_gettext (~> 1.1.0)
+      gettext (>= 3.0.2)
     kramdown (1.1.0)
+    locale (2.1.2)
     mime-types (1.24)
     multi_json (1.7.9)
+    public_suffix (1.4.6)
     rack (1.5.2)
     rack-test (0.6.2)
       rack (>= 1.0)
@@ -28,6 +37,7 @@ GEM
       multi_json (~> 1.0)
       simplecov-html (~> 0.7.1)
     simplecov-html (0.7.1)
+    text (1.3.1)
     vcr (2.5.0)
     webmock (1.9.3)
       addressable (>= 2.2.7)
@@ -35,13 +45,16 @@ GEM
     yard (0.8.7)
 
 PLATFORMS
-  java
   ruby
 
 DEPENDENCIES
   command_line_reporter (>= 3.0)
+  gettext-setup
   kramdown
   mime-types (< 2.0)
+  multi_json
+  public_suffix (~> 1.4.6)
+  rack (< 2.0.0)
   rack-test
   rake
   rest-client (< 1.7)

--- a/Rakefile
+++ b/Rakefile
@@ -74,3 +74,7 @@ namespace :package do
     end
   end
 end
+
+spec = Gem::Specification.find_by_name 'gettext-setup'
+load "#{spec.gem_dir}/lib/tasks/gettext.rake"
+GettextSetup.initialize(File.absolute_path('locales', File.dirname(__FILE__)))

--- a/bin/razor
+++ b/bin/razor
@@ -10,12 +10,16 @@ unless Kernel.respond_to?(:require_relative)
 end
 
 require 'rubygems'
+require 'gettext-setup'
 require_relative "../lib/razor/cli"
+
+GettextSetup.initialize(File.absolute_path('locales', File.dirname(File.dirname(__FILE__))))
+FastGettext.locale = GettextSetup.negotiate_locale(GettextSetup.this_locale)
 
 include Razor::CLI::Format
 
 def die(message = nil)
-  puts "Error: #{message}" if message
+  puts _("Error: %{error}") % {error: message} if message
   exit 1
 end
 
@@ -24,7 +28,7 @@ begin
 rescue Razor::CLI::InvalidURIError => e
   die e.message
 rescue OptionParser::InvalidOption => e
-  die e.message + "\nTry 'razor --help' for more information"
+  die _("%{error}\nTry 'razor --help' for more information") % {error: e.message}
 end
 
 if parse.show_version?
@@ -40,14 +44,13 @@ if parse.show_help? and not parse.show_command_help?
 end
 
 def unexpected_error(e)
-  die <<-ERROR
+  die _(<<-ERROR) % {backtrace: e.backtrace.take(10).join("\n"), error: e}
 An unexpected error has occurred.
 
 Backtrace:
-  #{e.backtrace.take(10).join('
-  ')}
+  %{backtrace}
 
-Error: #{e}
+Error: %{error}
 
 Please inspect server logs for the cause, then report issue to:
 https://tickets.puppetlabs.com/browse/RAZOR
@@ -58,22 +61,27 @@ end
 begin
   document = parse.navigate.get_document
   url = parse.navigate.last_url
-  puts "From #{url}:\n\n#{format_document document, parse}\n\n"
+  result = format_document document, parse
+  # TRANSLATORS: This is a template for all results that the client outputs.
+  puts _("From %{url}:\n\n%{result}\n\n") % {url: url, result: result}
 rescue OptionParser::InvalidOption => e
-  # Occurs when invalid flags are passed in the navigation.
-  die e.message + "\nTry 'razor --help' for more information"
+  # TRANSLATORS: This occurs when invalid flags are passed in the navigation.
+  die _("%{error}\nTry 'razor --help' for more information") %
+      {error: e.message}
 rescue SocketError, Errno::ECONNREFUSED => e
-  puts "Error: Could not connect to the server at #{parse.api_url}"
-  puts "       #{e}\n"
+  puts _("Error: Could not connect to the server at %{url}\n" +
+         "       %{error}") % {url: parse.api_url, error: e}
   die
 rescue RestClient::SSLCertificateNotVerified
-  puts "Error: SSL certificate could not be verified against known CA certificates."
-  puts "       To turn off verification, use the -k or --insecure option."
+  puts _("Error: SSL certificate could not be verified against known CA " +
+         "certificates.\n       To turn off verification, use the -k or --insecure option.")
   die
 rescue RestClient::Exception => e
   r = e.response
   unexpected_error(e) if r.nil?
-  puts "Error from doing #{r.args[:method].to_s.upcase} #{r.args[:url]}"
+  request_type = r.args[:method].to_s.upcase
+  url = r.args[:url]
+  puts _("Error from doing %{request_type} %{url}") % {request_type: request_type, url: url}
   puts e.message
   begin
     body = MultiJson::load(r.body)
@@ -88,5 +96,5 @@ rescue RestClient::Exception => e
   end
   die
 rescue StandardError => e
-  die "#{e.message}\nTry 'razor --help' for more information\n\n"
+  die _("%{error}\nTry 'razor --help' for more information\n\n") % {error: e.message}
 end

--- a/lib/razor/cli.rb
+++ b/lib/razor/cli.rb
@@ -6,9 +6,9 @@ module Razor
       def initialize(url, key, doc)
         @key = key; @doc = doc
         if key.is_a?(Array)
-          super "Could not navigate to '#{key.join(" ")}' from #{url}"
+          super _("Could not navigate to '%{path}' from %{url}") % {path: key.join(" "), url: url}
         else
-          super "Could not find entry '#{key}' in document at #{url}"
+          super _("Could not find entry '%{key}' in document at %{url}") % {key: key, url: url}
         end
       end
     end
@@ -17,24 +17,24 @@ module Razor
       def initialize(url, type)
         case type
         when :env
-          super "URL '#{url}' in ENV variable RAZOR_API is not valid"
+          super _("URL '%{url}' in ENV variable RAZOR_API is not valid") % {url: url}
         when :opts
-          super "URL '#{url}' provided by -u or --url is not valid"
+          super _("URL '%{url}' provided by -u or --url is not valid") % {url: url}
         else
-          super "URL '#{url}' is not valid"
+          super _("URL '%{url}' is not valid") % {url: url}
         end
       end
     end
 
     class InvalidCAFileError < Error
       def initialize(path)
-        super "CA file '#{path}' in ENV variable RAZOR_CA_FILE does not exist"
+        super _("CA file '%{path}' in ENV variable RAZOR_CA_FILE does not exist") % {path: path}
       end
     end
 
     class VersionCompatibilityError < Error
       def initialize(reason)
-        super "Server version is not compatible with client version: #{reason}"
+        super _("Server version is not compatible with client version: %{reason}") % {reason: reason}
       end
     end
 

--- a/lib/razor/cli/navigate.rb
+++ b/lib/razor/cli/navigate.rb
@@ -70,7 +70,7 @@ module Razor::CLI
     end
 
     def server_version
-      entrypoint.has_key?('version') and entrypoint['version']['server'] or 'Unknown'
+      entrypoint.has_key?('version') and entrypoint['version']['server'] or _('Unknown')
     end
 
     def query?
@@ -158,7 +158,7 @@ module Razor::CLI
 
       response = get(url,headers.merge(:accept => :json))
       unless response.headers[:content_type] =~ /application\/json/
-        raise "Received content type #{response.headers[:content_type]}"
+        raise _("Received content type %{content_type}") % {content_type: response.headers[:content_type]}
       end
       MultiJson.load(response.body)
     end
@@ -171,7 +171,7 @@ module Razor::CLI
       ensure
         if @parse.dump_response?
           print "POST #{url.to_s}\n#{body}\n-->\n"
-          puts (response ? response.body : "ERROR")
+          puts (response ? response.body : _("ERROR"))
         end
       end
       MultiJson::load(response.body)

--- a/lib/razor/cli/query.rb
+++ b/lib/razor/cli/query.rb
@@ -24,11 +24,11 @@ class Razor::CLI::Query
           doc[nav]['params'].is_a?(Hash) && doc[nav]['params']) || {}
     end
     @queryoptparse = OptionParser.new do |opts|
-      opts.on "-f", "--full", "Show full details when viewing entities" do
+      opts.on "-f", "--full", _("Show full details when viewing entities") do
         @parse.format = 'full'
       end
 
-      opts.on "-s", "--short", "Show shortened details when viewing entities" do
+      opts.on "-s", "--short", _("Show shortened details when viewing entities") do
         @parse.format = 'short'
       end
 

--- a/lib/razor/cli/transforms.rb
+++ b/lib/razor/cli/transforms.rb
@@ -8,13 +8,13 @@ module Razor::CLI
       obj.nil? ? "---" : obj
     end
     def join_names(arr)
-      (arr.nil? or arr.empty?) ? '(none)' : arr.map { |item| item['name'] }.join(", ")
+      (arr.nil? or arr.empty?) ? _('(none)') : arr.map { |item| item['name'] }.join(", ")
     end
     def nested(nested_obj)
-      (nested_obj.nil? or nested_obj.empty?) ? '(none)' : nested_obj.to_s
+      (nested_obj.nil? or nested_obj.empty?) ? _('(none)') : nested_obj.to_s
     end
     def shallow_hash(hash)
-      (hash.nil? or hash.empty?) ? '(none)' :
+      (hash.nil? or hash.empty?) ? _('(none)') :
           hash.map {|key, val| "#{key}: #{val}"}.join(', ')
     end
     def select_name(item)
@@ -59,14 +59,17 @@ module Razor::CLI
     end
     def event_entities(hash)
       hash ||= {}
-      shallow_hash(Hash[hash].keep_if {|k,_| ['task', 'policy', 'broker', 'repo', 'node', 'command'].include?(k)})
+      fields = ['task', 'policy', 'broker', 'repo', 'node', 'command']
+      shallow_hash(Hash[hash].keep_if {|k,_| fields.include?(k)})
     end
     def event_misc(hash)
       hash ||= {}
-      shallow_hash(Hash[hash].delete_if {|k,_|['task', 'policy', 'broker', 'repo', 'node', 'msg', 'command'].include?(k)})
+      fields = ['task', 'policy', 'broker', 'repo', 'node', 'msg', 'command']
+      shallow_hash(Hash[hash].delete_if {|k,_| fields.include?(k)})
     end
     def node_log_entry(hash)
-      shallow_hash(Hash[hash].delete_if {|k,_|['event', 'timestamp', 'severity'].include?(k)})
+      fields = ['event', 'timestamp', 'severity']
+      shallow_hash(Hash[hash].delete_if {|k,_| fields.include?(k)})
     end
   end
 end

--- a/locales/config.yaml
+++ b/locales/config.yaml
@@ -1,0 +1,24 @@
+---
+# This is the project-specific configuration file for setting up
+# fast_gettext for your project.
+gettext:
+  # This is used for the name of the .pot and .po files; they will be
+  # called <project_name>.pot?
+  project_name: 'razor-client'
+  # This is used in comments in the .pot and .po files to indicate what
+  # project the files belong to and should be a little more descriptive than
+  # <project_name>
+  package_name: Razor Client
+  # The locale that the default messages in the .pot file are in
+  default_locale: en
+  # The email used for sending bug reports.
+  bugs_address: docs@puppet.com
+  # The holder of the copyright.
+  copyright_holder: Puppet Inc.
+  # This determines which comments in code should be eligible for translation.
+  comments_tag: TRANSLATORS
+  # Patterns for +Dir.glob+ used to find all files that might contain
+  # translatable content, relative to the project root directory
+  source_files:
+    - 'lib/**/*.rb'
+    - 'bin/razor'

--- a/locales/razor-client.pot
+++ b/locales/razor-client.pot
@@ -1,0 +1,268 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2017 Puppet, LLC.
+# This file is distributed under the same license as the Razor Client package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Razor Client 1.3.0-3-ga296fc7\n"
+"\n"
+"Report-Msgid-Bugs-To: docs@puppet.com\n"
+"POT-Creation-Date: 2017-01-12 03:03-0600\n"
+"PO-Revision-Date: 2017-01-12 03:03-0600\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+
+msgid "Error: %{error}"
+msgstr ""
+
+#. TRANSLATORS: This occurs when invalid flags are passed in the navigation.
+msgid ""
+"%{error}\n"
+"Try 'razor --help' for more information"
+msgstr ""
+
+msgid ""
+"An unexpected error has occurred.\n"
+"\n"
+"Backtrace:\n"
+"  %{backtrace}\n"
+"\n"
+"Error: %{error}\n"
+"\n"
+"Please inspect server logs for the cause, then report issue to:\n"
+"https://tickets.puppetlabs.com/browse/RAZOR\n"
+"\n"
+msgstr ""
+
+#. TRANSLATORS: This is a template for all results that the client outputs.
+msgid ""
+"From %{url}:\n"
+"\n"
+"%{result}\n"
+"\n"
+msgstr ""
+
+msgid ""
+"Error: Could not connect to the server at %{url}\n"
+"       %{error}"
+msgstr ""
+
+msgid ""
+"Error: SSL certificate could not be verified against known CA certificates.\n"
+"       To turn off verification, use the -k or --insecure option."
+msgstr ""
+
+msgid "Error from doing %{request_type} %{url}"
+msgstr ""
+
+msgid ""
+"%{error}\n"
+"Try 'razor --help' for more information\n"
+"\n"
+msgstr ""
+
+msgid "Could not navigate to '%{path}' from %{url}"
+msgstr ""
+
+msgid "Could not find entry '%{key}' in document at %{url}"
+msgstr ""
+
+msgid "URL '%{url}' in ENV variable RAZOR_API is not valid"
+msgstr ""
+
+msgid "URL '%{url}' provided by -u or --url is not valid"
+msgstr ""
+
+msgid "URL '%{url}' is not valid"
+msgstr ""
+
+msgid "CA file '%{path}' in ENV variable RAZOR_CA_FILE does not exist"
+msgstr ""
+
+msgid "Server version is not compatible with client version: %{reason}"
+msgstr ""
+
+msgid "No arguments for command (did you forget --json ?)"
+msgstr ""
+
+msgid "Unexpected argument %{argument} (did you mean %{suggestion}?)"
+msgstr ""
+
+msgid "Unexpected argument %{argument}"
+msgstr ""
+
+msgid "File %{path} is not valid JSON"
+msgstr ""
+
+msgid "File %{path} not found"
+msgstr ""
+
+msgid "Permission to read file %{path} denied"
+msgstr ""
+
+msgid ""
+"Formatting argument %{argument_name} with value %{value} as %{argument_type}\n"
+msgstr ""
+
+msgid "Invalid object for argument '%{argument_name}'"
+msgstr ""
+
+msgid "Invalid object for argument '%{argument_name}': %{error}"
+msgstr ""
+
+msgid "Invalid integer for argument '%{arg_name}': %{value}"
+msgstr ""
+
+msgid "Expected nothing for argument '%{arg_name}', but was: '%{value}'"
+msgstr ""
+
+msgid "Unexpected datatype '%{argument_type}' for argument %{argument_name}"
+msgstr ""
+
+msgid "There are no items for this query."
+msgstr ""
+
+msgid "Unrecognized view format %{format_name}"
+msgstr ""
+
+msgid "Could not find help for that entry"
+msgstr ""
+
+msgid ""
+"# USAGE\n"
+"\n"
+"  razor %{command} %{arguments} <flags>\n"
+"\n"
+msgstr ""
+
+msgid ""
+"# SYNOPSIS\n"
+"%{summary}\n"
+"\n"
+msgstr ""
+
+msgid ""
+"# DESCRIPTION\n"
+"%{description}\n"
+"\n"
+"%{schema}\n"
+msgstr ""
+
+msgid ""
+"# RETURNS\n"
+"%{returns}\n"
+msgstr ""
+
+msgid ""
+"# EXAMPLES\n"
+"\n"
+"%{examples}\n"
+msgstr ""
+
+msgid ""
+"\n"
+"\n"
+"Query an entry by including its name, e.g. `razor %{arguments} %{name}`"
+msgstr ""
+
+msgid ""
+"\n"
+"\n"
+"Query additional details via: `razor %{arguments} [%{options}]`"
+msgstr ""
+
+msgid "Unknown"
+msgstr ""
+
+msgid "Received content type %{content_type}"
+msgstr ""
+
+msgid "ERROR"
+msgstr ""
+
+msgid ""
+"Usage: razor [FLAGS] NAVIGATION\n"
+msgstr ""
+
+msgid "Dumps API output to the screen"
+msgstr ""
+
+msgid "Show API help for a command"
+msgstr ""
+
+msgid "Allow SSL connections without verified certificates"
+msgstr ""
+
+msgid ""
+"The full Razor API URL, can also be set\n"
+" "
+msgstr ""
+
+msgid "Show the version of Razor"
+msgstr ""
+
+msgid "Show this screen"
+msgstr ""
+
+msgid "Error: Credentials are required to connect to the server at %{url}."
+msgstr ""
+
+msgid "Error: Could not connect to the server at %{url}."
+msgstr ""
+
+msgid ""
+"        Razor Server version: #{server_version}\n"
+"        Razor Client version: #{Razor::CLI::VERSION}\n"
+msgstr ""
+
+msgid "Collections"
+msgstr ""
+
+msgid "Commands"
+msgstr ""
+
+msgid ""
+"%{collections}\n"
+"\n"
+"      Navigate to entries of a collection using COLLECTION NAME, for example,\n"
+"      'nodes node15'  for the  details of a node or 'nodes node15 log' to see\n"
+"      the log for node15\n"
+"%{commands}\n"
+"\n"
+"      Pass arguments to commands either directly by name ('--name=NAME')\n"
+"      or save the JSON body for the  command  in a file and pass it with\n"
+"      '--json FILE'.  Using --json is the only way to pass  arguments in\n"
+"      nested structures such as the configuration for a broker.\n"
+"\n"
+msgstr ""
+
+msgid ""
+"Error: Credentials are required to connect to the server at %{url}\"\n"
+msgstr ""
+
+msgid "Error: Could not connect to the server at %{url}"
+msgstr ""
+
+msgid "Error: SSL certificate error from server at %{url}"
+msgstr ""
+
+msgid ""
+"Error: Unknown error occurred while connecting to server at %{url}:\n"
+"       #{e}\n"
+msgstr ""
+
+msgid "Show full details when viewing entities"
+msgstr ""
+
+msgid "Show shortened details when viewing entities"
+msgstr ""
+
+msgid "(none)"
+msgstr ""

--- a/spec/locales/config.yaml
+++ b/spec/locales/config.yaml
@@ -1,0 +1,24 @@
+---
+# This is the project-specific configuration file for setting up
+# fast_gettext for your project.
+gettext:
+  # This is used for the name of the .pot and .po files; they will be
+  # called <project_name>.pot?
+  project_name: 'razor-client'
+  # This is used in comments in the .pot and .po files to indicate what
+  # project the files belong to and should be a little more descriptive than
+  # <project_name>
+  package_name: Razor Client
+  # The locale that the default messages in the .pot file are in
+  default_locale: en
+  # The email used for sending bug reports.
+  bugs_address: docs@puppet.com
+  # The holder of the copyright.
+  copyright_holder: Puppet Inc.
+  # This determines which comments in code should be eligible for translation.
+  comments_tag: TRANSLATORS
+  # Patterns for +Dir.glob+ used to find all files that might contain
+  # translatable content, relative to the project root directory
+  source_files:
+    - 'lib/**/*.rb'
+    - 'bin/razor'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,9 @@ end
 require 'multi_json'
 require 'vcr'
 
+require 'gettext-setup'
+GettextSetup.initialize(File.absolute_path('locales', File.dirname(__FILE__)))
+
 require_relative '../lib/razor'
 require_relative 'vcr_library'
 


### PR DESCRIPTION
In order for error messages generated by this client to be translated, we
need to pass the error messages through gettext. This pulls in the
gettext-setup gem and passes error messages through the gettext method for
translation.

Fixes https://tickets.puppetlabs.com/browse/RAZOR-858