### PR TITLE
Drop support for Ruby < 2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,13 +1,11 @@
 source 'https://rubygems.org'
 
-# mime-types is a dependency of rest-client. We need to explicitly depend
-# on it and pin its version to make sure this works with Ruby 1.8.7
-gem 'mime-types', '< 2.0'
-# `rest-client` adds an undesirable dependency on Ruby >= 1.9.2 in version 1.7.0.
-gem 'rest-client', '< 1.7'
+raise 'Ruby should be >2.0' unless RUBY_VERSION.to_f > 2.0
+
+gem 'rest-client', '> 2.0.0'
 gem 'command_line_reporter', '>=3.0'
 gem 'gettext-setup'
-gem 'rack', '< 2.0.0'
+gem 'rack', '< 2.0.0', '>= 1.5.4'
 gem 'multi_json'
 
 group :doc do
@@ -24,8 +22,8 @@ group :test do
   gem 'rspec-expectations', '~> 2.13.0'
   gem 'rspec-mocks', '~> 2.13.1'
   gem 'simplecov'
-  gem 'webmock'
-  gem 'vcr'
+  gem 'webmock', '~> 2.3.1'
+  gem 'vcr', '~> 4.0.0'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,30 +1,45 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.3.3)
+    addressable (2.4.0)
     colored (1.2)
     command_line_reporter (3.3.2)
       colored (>= 1.2)
-    crack (0.3.2)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     diff-lcs (1.2.4)
-    fast_gettext (1.1.0)
-    gettext (3.2.2)
+    docile (1.1.5)
+    domain_name (0.5.20170404)
+      unf (>= 0.0.5, < 1.0.0)
+    fast_gettext (1.1.1)
+    gettext (3.2.6)
       locale (>= 2.0.5)
       text (>= 1.3.0)
-    gettext-setup (0.14)
+    gettext-setup (0.29)
       fast_gettext (~> 1.1.0)
       gettext (>= 3.0.2)
+      locale
+    hashdiff (0.3.7)
+    http-cookie (1.0.3)
+      domain_name (~> 0.5)
+    json (2.1.0)
+    json (2.1.0-java)
     kramdown (1.1.0)
     locale (2.1.2)
-    mime-types (1.24)
-    multi_json (1.7.9)
+    mime-types (3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2016.0521)
+    multi_json (1.13.1)
+    netrc (0.11.0)
     public_suffix (1.4.6)
-    rack (1.5.2)
+    rack (1.6.8)
     rack-test (0.6.2)
       rack (>= 1.0)
     rake (10.1.0)
-    rest-client (1.6.7)
-      mime-types (>= 1.16)
+    rest-client (2.0.2)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     rspec (2.13.0)
       rspec-core (~> 2.13.0)
       rspec-expectations (~> 2.13.0)
@@ -33,16 +48,23 @@ GEM
     rspec-expectations (2.13.0)
       diff-lcs (>= 1.1.3, < 2.0)
     rspec-mocks (2.13.1)
-    simplecov (0.7.1)
-      multi_json (~> 1.0)
-      simplecov-html (~> 0.7.1)
-    simplecov-html (0.7.1)
+    safe_yaml (1.0.4)
+    simplecov (0.15.1)
+      docile (~> 1.1.0)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
     text (1.3.1)
-    vcr (2.5.0)
-    webmock (1.9.3)
-      addressable (>= 2.2.7)
+    unf (0.1.4)
+      unf_ext
+    unf (0.1.4-java)
+    unf_ext (0.0.7.4)
+    vcr (4.0.0)
+    webmock (2.3.2)
+      addressable (>= 2.3.6)
       crack (>= 0.3.2)
-    yard (0.8.7)
+      hashdiff
+    yard (0.9.12)
 
 PLATFORMS
   java
@@ -52,21 +74,20 @@ DEPENDENCIES
   command_line_reporter (>= 3.0)
   gettext-setup
   kramdown
-  mime-types (< 2.0)
   multi_json
   public_suffix (~> 1.4.6)
-  rack (< 2.0.0)
+  rack (>= 1.5.4, < 2.0.0)
   rack-test
   rake
-  rest-client (< 1.7)
+  rest-client (> 2.0.0)
   rspec (~> 2.13.0)
   rspec-core (~> 2.13.1)
   rspec-expectations (~> 2.13.0)
   rspec-mocks (~> 2.13.1)
   simplecov
-  vcr
-  webmock
+  vcr (~> 4.0.0)
+  webmock (~> 2.3.1)
   yard
 
 BUNDLED WITH
-   1.13.6
+   1.16.1

--- a/bin/razor
+++ b/bin/razor
@@ -1,14 +1,5 @@
 #!/usr/bin/env ruby
 
-# Needed to make the client work on Ruby 1.8.7
-unless Kernel.respond_to?(:require_relative)
-  module Kernel
-    def require_relative(path)
-      require File.join(File.dirname(caller[0]), path.to_str)
-    end
-  end
-end
-
 require 'rubygems'
 require 'gettext-setup'
 require_relative "../lib/razor/cli"
@@ -60,10 +51,15 @@ end
 
 begin
   document = parse.navigate.get_document
+  p document
   url = parse.navigate.last_url
   result = format_document document, parse
   # TRANSLATORS: This is a template for all results that the client outputs.
   puts _("From %{url}:\n\n%{result}\n\n") % {url: url, result: result}
+rescue RestClient::Unauthorized
+  puts _(<<-UNAUTH) % {url: url}
+Error: Credentials are required to connect to the server at %{url}"
+  UNAUTH
 rescue OptionParser::InvalidOption => e
   # TRANSLATORS: This occurs when invalid flags are passed in the navigation.
   die _("%{error}\nTry 'razor --help' for more information") %
@@ -79,6 +75,7 @@ rescue RestClient::SSLCertificateNotVerified
 rescue RestClient::Exception => e
   r = e.response
   unexpected_error(e) if r.nil?
+  p r.methods
   request_type = r.args[:method].to_s.upcase
   url = r.args[:url]
   puts _("Error from doing %{request_type} %{url}") % {request_type: request_type, url: url}

--- a/razor-client.gemspec
+++ b/razor-client.gemspec
@@ -22,16 +22,14 @@ Gem::Specification.new do |spec|
   # e.g. https://tickets.puppetlabs.com/browse/RAZOR-572. This is only
   # effective for locally built gems, as project_data.yaml does not support
   # this feature.
-  spec.required_ruby_version = '>= 1.9.2'
+  spec.required_ruby_version = '>= 2.0.0'
 
-  # mime-types is a dependency of rest-client. We need to explicitly depend
-  # on it and pin its version to make sure the gem works with Ruby 1.8.7
-  spec.add_dependency "mime-types", '< 2.0'
+  spec.add_dependency "mime-types"
   spec.add_dependency "multi_json"
-  # `rest-client` adds an undesirable dependency on Ruby >= 1.9.2 in version 1.7.0.
-  spec.add_dependency "rest-client", '< 1.7'
+  # `rest-client` has a security vulnerability prior to this version.
+  spec.add_dependency "rest-client", '~> 2.0'
   spec.add_dependency "command_line_reporter", '~> 3.0'
-  spec.add_dependency "gettext-setup"
+  spec.add_dependency "gettext-setup", '~> 0.29'
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"

--- a/spec/fixtures/vcr/Razor_CLI_Navigate/with_authentication/should_preserve_that_across_navigation.yml
+++ b/spec/fixtures/vcr/Razor_CLI_Navigate/with_authentication/should_preserve_that_across_navigation.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://fred:dead@localhost:8150/api
+    uri: http://localhost:8150/api
     body:
       encoding: US-ASCII
       string: ''
@@ -35,7 +35,7 @@ http_interactions:
   recorded_at: Mon, 09 Mar 2015 19:54:50 GMT
 - request:
     method: get
-    uri: http://fred:dead@localhost:8150/api/collections/tags
+    uri: http://localhost:8150/api/collections/tags
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr/Razor_CLI_Navigate/with_authentication/should_supply_that_to_the_API_service.yml
+++ b/spec/fixtures/vcr/Razor_CLI_Navigate/with_authentication/should_supply_that_to_the_API_service.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://fred:dead@localhost:8150/api
+    uri: http://localhost:8150/api
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr/Razor_CLI_Navigate/with_query_parameters/should_append_limit.yml
+++ b/spec/fixtures/vcr/Razor_CLI_Navigate/with_query_parameters/should_append_limit.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://fred:dead@localhost:8150/api
+    uri: http://localhost:8150/api
     body:
       encoding: US-ASCII
       string: ''
@@ -35,7 +35,7 @@ http_interactions:
   recorded_at: Mon, 09 Mar 2015 19:54:56 GMT
 - request:
     method: get
-    uri: http://fred:dead@localhost:8150/api/collections/events?limit=1
+    uri: http://localhost:8150/api/collections/events?limit=1
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr/Razor_CLI_Navigate/with_query_parameters/should_append_start.yml
+++ b/spec/fixtures/vcr/Razor_CLI_Navigate/with_query_parameters/should_append_start.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://fred:dead@localhost:8150/api
+    uri: http://localhost:8150/api
     body:
       encoding: US-ASCII
       string: ''
@@ -35,7 +35,7 @@ http_interactions:
   recorded_at: Mon, 09 Mar 2015 19:55:01 GMT
 - request:
     method: get
-    uri: http://fred:dead@localhost:8150/api/collections/events?start=1
+    uri: http://localhost:8150/api/collections/events?start=1
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr/Razor_CLI_Navigate/with_query_parameters/should_not_fail_when_query_returns_details_for_one_item.yml
+++ b/spec/fixtures/vcr/Razor_CLI_Navigate/with_query_parameters/should_not_fail_when_query_returns_details_for_one_item.yml
@@ -213,7 +213,7 @@ http_interactions:
   recorded_at: Mon, 09 Mar 2015 19:55:12 GMT
 - request:
     method: get
-    uri: http://fred:dead@localhost:8150/api
+    uri: http://localhost:8150/api
     body:
       encoding: US-ASCII
       string: ''
@@ -246,7 +246,7 @@ http_interactions:
   recorded_at: Mon, 09 Mar 2015 19:55:12 GMT
 - request:
     method: get
-    uri: http://fred:dead@localhost:8150/api/collections/nodes
+    uri: http://localhost:8150/api/collections/nodes
     body:
       encoding: US-ASCII
       string: ''
@@ -279,7 +279,7 @@ http_interactions:
   recorded_at: Mon, 09 Mar 2015 19:55:12 GMT
 - request:
     method: get
-    uri: http://fred:dead@localhost:8150/api/collections/nodes/node1
+    uri: http://localhost:8150/api/collections/nodes/node1
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr/Razor_CLI_Navigate/with_query_parameters/should_store_query_without_query_parameters.yml
+++ b/spec/fixtures/vcr/Razor_CLI_Navigate/with_query_parameters/should_store_query_without_query_parameters.yml
@@ -424,7 +424,7 @@ http_interactions:
   recorded_at: Mon, 09 Mar 2015 19:55:24 GMT
 - request:
     method: get
-    uri: http://fred:dead@localhost:8150/api
+    uri: http://localhost:8150/api
     body:
       encoding: US-ASCII
       string: ''
@@ -457,7 +457,7 @@ http_interactions:
   recorded_at: Mon, 09 Mar 2015 19:55:24 GMT
 - request:
     method: get
-    uri: http://fred:dead@localhost:8150/api/collections/nodes
+    uri: http://localhost:8150/api/collections/nodes
     body:
       encoding: US-ASCII
       string: ''
@@ -490,7 +490,7 @@ http_interactions:
   recorded_at: Mon, 09 Mar 2015 19:55:24 GMT
 - request:
     method: get
-    uri: http://fred:dead@localhost:8150/api/collections/nodes/node1
+    uri: http://localhost:8150/api/collections/nodes/node1
     body:
       encoding: US-ASCII
       string: ''
@@ -523,7 +523,7 @@ http_interactions:
   recorded_at: Mon, 09 Mar 2015 19:55:24 GMT
 - request:
     method: get
-    uri: http://fred:dead@localhost:8150/api/collections/nodes/node1/log?limit=1
+    uri: http://localhost:8150/api/collections/nodes/node1/log?limit=1
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr/Razor_CLI_Navigate/with_query_parameters/should_throw_an_error_if_the_query_parameter_is_not_in_the_API.yml
+++ b/spec/fixtures/vcr/Razor_CLI_Navigate/with_query_parameters/should_throw_an_error_if_the_query_parameter_is_not_in_the_API.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://fred:dead@localhost:8150/api
+    uri: http://localhost:8150/api
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr/Razor_CLI_Navigate/with_query_parameters/should_throw_an_error_if_the_query_parameter_is_not_in_the_API_from_a_single_item.yml
+++ b/spec/fixtures/vcr/Razor_CLI_Navigate/with_query_parameters/should_throw_an_error_if_the_query_parameter_is_not_in_the_API_from_a_single_item.yml
@@ -213,7 +213,7 @@ http_interactions:
   recorded_at: Mon, 09 Mar 2015 19:55:18 GMT
 - request:
     method: get
-    uri: http://fred:dead@localhost:8150/api
+    uri: http://localhost:8150/api
     body:
       encoding: US-ASCII
       string: ''
@@ -246,7 +246,7 @@ http_interactions:
   recorded_at: Mon, 09 Mar 2015 19:55:18 GMT
 - request:
     method: get
-    uri: http://fred:dead@localhost:8150/api/collections/nodes
+    uri: http://localhost:8150/api/collections/nodes
     body:
       encoding: US-ASCII
       string: ''


### PR DESCRIPTION
Some security vulnerabilities in gem dependencies, specifically
rest-client, are making support for ruby 1.8.7 and 1.9.3 very difficult.

This commit removes support for Ruby prior to 2.0 and updates to later
versions of several gems that were previously pinned.
  
Fixes https://tickets.puppetlabs.com/browse/RAZOR-1041