### PR TITLE
Pin `gettext-setup` gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ end
 
 gem 'rest-client', '> 2.0.0'
 gem 'command_line_reporter', '>=3.0'
-gem 'gettext-setup'
+gem 'gettext-setup', '>= 0.31'
 gem 'rack', '< 2.0.0', '>= 1.5.4'
 gem 'multi_json'
 gem 'domain_name', '>= 0.5.20180417'

--- a/razor-client.gemspec
+++ b/razor-client.gemspec
@@ -29,11 +29,11 @@ Gem::Specification.new do |spec|
   # `rest-client` has a security vulnerability prior to this version.
   spec.add_dependency "rest-client", '~> 2.0'
   spec.add_dependency "command_line_reporter", '~> 3.0'
-  spec.add_dependency "gettext-setup", '~> 0.29'
+  spec.add_dependency "gettext-setup", '>= 0.31'
   spec.add_dependency "domain_name", '>= 0.5.20180417'
   # This version of UNF does not require native extensions for Ruby >= 2.2.
   spec.add_dependency 'unf', '>= 0.2.0.beta2'
 
-  spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
 end


### PR DESCRIPTION
An error shows up if the `gettext-setup` gem is a version prior to
0.11. This bumps to the latest version, as several other changes in
that gem may be useful.