### PR TITLE
Pin `unf` to 0.1.4 (requiring native extensions)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ gem 'gettext-setup', '>= 0.31'
 gem 'rack', '< 2.0.0', '>= 1.5.4'
 gem 'multi_json'
 gem 'domain_name', '>= 0.5.20180417'
-gem 'unf', '>= 0.2.0.beta2'
+gem 'unf', '>= 0.1.4'
 
 group :packaging do
   gem 'packaging', *location_for(ENV['PACKAGING_LOCATION'] || '~> 0.99')

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,12 @@
 # Razor Client Release Notes
 
-## 1.9.2 - 2019-08-14
+## 1.9.3 - 2019-08-19
+
+* BUGFIX: The `unf` gem dependency referenced a prerelease version of a gem.
+  Rather than force the use of `--pre` when installing the gem, we will pin
+  back to the released version, which requires GCC to build native extensions.
+
+## 1.9.2 - 2019-08-14 (yanked)
 
 * BUGFIX: Fixed error output when number or null datatypes are invalid.
 * IMPROVEMENT: Now exits with status code 1 if login credentials are missing.

--- a/razor-client.gemspec
+++ b/razor-client.gemspec
@@ -31,8 +31,10 @@ Gem::Specification.new do |spec|
   spec.add_dependency "command_line_reporter", '~> 3.0'
   spec.add_dependency "gettext-setup", '>= 0.31'
   spec.add_dependency "domain_name", '>= 0.5.20180417'
-  # This version of UNF does not require native extensions for Ruby >= 2.2.
-  spec.add_dependency 'unf', '>= 0.2.0.beta2'
+  # We are stuck on this version until `unf` releases `0.2.0.beta2` as a proper
+  # release. This version of UNF requires native extensions for Ruby >= 2.2,
+  # meaning GCC is a requirement on those systems.
+  spec.add_dependency 'unf', '>= 0.1.4'
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
Since `unf` version `0.2.0.beta2` hasn't been properly released at this
point, we will pin to 0.1.4 again. The trade-off here is between
requiring `--pre` for the prerelease version of the gem, and requiring
GCC to be installed for the released version of the gem. The latter is
what our most recent release follows, so we will stick with that.

We may wish to release `unf`'s `0.2.0.beta2` release out of band, which
will remove the need for building native extensions.

Fixes https://github.com/puppetlabs/RAZOR-1111