### PR TITLE
Better handling of empty boolean arguments

### DIFF
--- a/lib/razor/cli/command.rb
+++ b/lib/razor/cli/command.rb
@@ -35,7 +35,7 @@ class Razor::CLI::Command
         # `--arg=value`/`--arg value`
         # `-a=value`/`-a value`
         arg_name, value = [$1, $3]
-        value = @segments.shift if value.nil? && @segments[0] !~ /^-[a-z]/
+        value = @segments.shift if value.nil? && @segments[0] !~ /^-[-]?[a-z]/
         arg_name = self.class.resolve_alias(arg_name, @cmd_schema)
         body[arg_name] = self.class.convert_arg(arg_name, value, body[arg_name], @cmd_schema)
       elsif argument =~ /\A-([a-z][a-z_-]+)(=(.+))?\Z/ and
@@ -127,7 +127,9 @@ class Razor::CLI::Command
               {argument_name: arg_name, error: error.message}
         end
       when "boolean"
-        ["true", nil].include?(value)
+        raise ArgumentError, _("Invalid boolean for argument '%{argument_name}': %{value}") %
+            {argument_name: arg_name, value: value} unless ["true", "false", nil].include?(value)
+        value != "false"
       when "number"
         begin
           Integer(value)

--- a/spec/cli/command_spec.rb
+++ b/spec/cli/command_spec.rb
@@ -60,6 +60,16 @@ describe Razor::CLI::Command do
             to raise_error(ArgumentError, /Expected nothing for argument 'tags', but was: 'abc'/)
       end
     end
+    context "boolean conversion" do
+      it "errors when anything besides 'true', 'false' or nil are provided" do
+        cmd_schema = {"enabled"=>{"type"=>"boolean"}}
+        expect{Command.convert_arg('enabled', 'abc', existing_value, cmd_schema)}.
+            to raise_error(ArgumentError, /Invalid boolean for argument 'enabled': abc/)
+        expect(Command.convert_arg('enabled', 'true', existing_value, cmd_schema)).to eq(true)
+        expect(Command.convert_arg('enabled', nil, existing_value, cmd_schema)).to eq(true)
+        expect(Command.convert_arg('enabled', 'false', existing_value, cmd_schema)).to eq(false)
+      end
+    end
   end
 
   context "resolve_alias" do
@@ -104,6 +114,9 @@ describe Razor::CLI::Command do
       it "succeeds with a double dash for long flags" do
         extract({'schema' => {'name' => {'type' => 'array'}}},
                 ['--name', 'abc'])['name'].should == ['abc']
+        extract({'schema' => {'true' => {'type' => 'boolean'},
+                                      'other' => {'type' => 'number'}}},
+                ['--true', '--other', '123'])['true'].should be_true
       end
       it "succeeds with a single dash for short flags" do
         c = Razor::CLI::Command.new(nil, nil, {'schema' => {'n' => {'type' => 'array'}}},


### PR DESCRIPTION
Given this example: `razor create-policy ... --enabled --hostname
'host${id}.com' ...`

Razor is thinking `--hostname` is the value for `--enabled`, and
`'host${id}.com'` is then treated as a positional argument.

This makes two changes which should fix this issue:
- Boolean types must now be `"true"`, `"false"`, or `nil`/empty. The
latter-most evaluates to `"true"`.
- Any value for a boolean type starting with two dashes should be
counted as the next argument.

Fixes https://tickets.puppetlabs.com/browse/RAZOR-1114